### PR TITLE
api validation

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1316,6 +1316,15 @@
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
+    "celebrate": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-9.0.2.tgz",
+      "integrity": "sha512-dNn3wH80QM0k4rw9ubOZUUN//xvKGa7ZGbb4NBcm1dXBiDdNmneJE77w0GrWeOA1lOAjs0843lF+/9+hyCRqow==",
+      "requires": {
+        "escape-html": "1.0.3",
+        "joi": "14.x.x"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3105,6 +3114,11 @@
         }
       }
     },
+    "hoek": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+    },
     "home-or-tmp": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
@@ -3636,6 +3650,14 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3647,6 +3669,16 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "joi": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "requires": {
+        "hoek": "6.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4714,8 +4746,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -5566,6 +5597,14 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
       }
     },
     "toposort": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1316,15 +1316,6 @@
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
-    "celebrate": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-9.0.2.tgz",
-      "integrity": "sha512-dNn3wH80QM0k4rw9ubOZUUN//xvKGa7ZGbb4NBcm1dXBiDdNmneJE77w0GrWeOA1lOAjs0843lF+/9+hyCRqow==",
-      "requires": {
-        "escape-html": "1.0.3",
-        "joi": "14.x.x"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -45,8 +45,8 @@
     "pretty-quick": "^1.10.0"
   },
   "dependencies": {
-    "celebrate": "^9.0.2",
     "express": "^4.16.4",
+    "joi": "^14.3.1",
     "stripe": "^6.23.1"
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -45,6 +45,7 @@
     "pretty-quick": "^1.10.0"
   },
   "dependencies": {
+    "celebrate": "^9.0.2",
     "express": "^4.16.4",
     "stripe": "^6.23.1"
   }

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -2,6 +2,7 @@
 import express from 'express'
 import bodyParser from 'body-parser'
 import envVarValidation from './libs/envVarValidation'
+import { errors } from 'celebrate'
 
 // Check if required env vars are set the right format
 envVarValidation()
@@ -44,5 +45,8 @@ router.get('/', (req, res) => {
 import billingController from './controllers/billing'
 
 billingController(router)
+
+// use celebrate error handler to return 400s for invalid payloads
+app.use(errors)
 
 export default app

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -2,7 +2,6 @@
 import express from 'express'
 import bodyParser from 'body-parser'
 import envVarValidation from './libs/envVarValidation'
-import { errors } from 'celebrate'
 
 // Check if required env vars are set the right format
 envVarValidation()
@@ -45,8 +44,5 @@ router.get('/', (req, res) => {
 import billingController from './controllers/billing'
 
 billingController(router)
-
-// use celebrate error handler to return 400s for invalid payloads
-app.use(errors)
 
 export default app

--- a/api/src/controllers/billing.js
+++ b/api/src/controllers/billing.js
@@ -1,14 +1,15 @@
 import billingCoordinator from '../coordinators/billing'
-import { Joi, celebrate } from 'celebrate'
+import Joi from 'joi'
+import validate from '../libs/payloadValidation'
 
 const billingController = function(router) {
   router.post(
     '/billing',
-    celebrate({
+    validate({
       body: Joi.object().keys({
         token: Joi.string().required(),
         planId: Joi.string().required(),
-        email: Joi.email().required()
+        email: Joi.string().email().required()
       })
     }),
     addBilling

--- a/api/src/controllers/billing.js
+++ b/api/src/controllers/billing.js
@@ -1,7 +1,18 @@
 import billingCoordinator from '../coordinators/billing'
+import { Joi, celebrate } from 'celebrate'
 
 const billingController = function(router) {
-  router.post('/billing', addBilling)
+  router.post(
+    '/billing',
+    celebrate({
+      body: Joi.object().keys({
+        token: Joi.string().required(),
+        planId: Joi.string().required(),
+        email: Joi.email().required()
+      })
+    }),
+    addBilling
+  )
 }
 
 const addBilling = async function(req, res) {

--- a/api/src/controllers/billing.js
+++ b/api/src/controllers/billing.js
@@ -2,16 +2,18 @@ import billingCoordinator from '../coordinators/billing'
 import Joi from 'joi'
 import validate from '../libs/payloadValidation'
 
+const billingPayloadSchema = Joi.compile({
+  body: Joi.object().keys({
+    token: Joi.string().required(),
+    planId: Joi.string().required(),
+    email: Joi.string().email().required()
+  })
+})
+
 const billingController = function(router) {
   router.post(
     '/billing',
-    validate({
-      body: Joi.object().keys({
-        token: Joi.string().required(),
-        planId: Joi.string().required(),
-        email: Joi.string().email().required()
-      })
-    }),
+    validate(billingPayloadSchema),
     addBilling
   )
 }

--- a/api/src/libs/payloadValidation.js
+++ b/api/src/libs/payloadValidation.js
@@ -1,0 +1,15 @@
+import Joi from 'joi'
+
+export default function validate(schema) {
+  return (req, res, next) => {
+    const { error } = Joi.validate(req, schema, {
+      allowUnknown: true
+    })
+
+    if (!error) {
+      return next()
+    }
+
+    res.status(400).send('Invalid request payload input')
+  }
+}


### PR DESCRIPTION
- sets up basic validation middleware using joi
- note that we don't want to compile the joi schemas at runtime, so it's pre compiled at the module level
- also note that we're not logging any data beyond whatever 400 response logs will get generated by express
- also the current settings will cast to the type and mutate the response body, query, etc. if "1" is passed to a field wanting a Joi.number() it will be cast to a number
- we may want to lock this down to just body, request, and headers on the request object, but I think it's ok to leave open ended for now