### PR TITLE
Web login auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ To get started, you'll need Docker installed, then run the following commands
 ```
 // Local development
 cp api/example.env api/.env
+cp web/src/server/example.env web/src/server/.env
 make builddev
 make start
 make stop

--- a/api/src/controllers/loader.js
+++ b/api/src/controllers/loader.js
@@ -15,7 +15,7 @@ const UNAUTHENTICATED_CONTROLLERS = {
 }
 
 const loadControllers = (router, controllers, middleware) => {
-  Object.keys(controllers).forEach(path => {
+  Object.keys(controllers).forEach((path) => {
     const controllerFileName = controllers[path]
     const controller = require(`./${controllerFileName}`).default
     const controllerRouter = express.Router()
@@ -28,7 +28,7 @@ const loadControllers = (router, controllers, middleware) => {
   })
 }
 
-const loader = router => {
+const loader = (router) => {
   loadControllers(router, AUTHENTICATED_CONTROLLERS, [
     auth.jwtMiddleware
   ])

--- a/api/src/libs/auth.js
+++ b/api/src/libs/auth.js
@@ -2,7 +2,7 @@ import passport from 'passport'
 import JWTAuth from './passportJWT'
 import localAuth from './passportLocal'
 
-const init = passport => {
+const init = (passport) => {
   passport.serializeUser((user, done) => {
     done(null, user.email)
   })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     command: devstart
     ports:
       - 3000:3000
+    env_file:
+      - ./web/src/server/.env
     environment:
       NODE_ENV: development
 
@@ -27,6 +29,8 @@ services:
     command: devstart
     ports:
       - 3001:3001
+    env_file:
+      - ./api/.env
     environment:
       NODE_ENV: development
       API_PORT: 3001

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -4,3 +4,5 @@ node_modules/
 coverage
 (/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$
 **/__mocks__
+**/example.env
+**/.env

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1652,6 +1652,15 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -5026,6 +5035,29 @@
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "requires": {
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -5131,7 +5163,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5152,12 +5185,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5172,17 +5207,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5299,7 +5337,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5311,6 +5350,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5325,6 +5365,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5332,12 +5373,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5356,6 +5399,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5436,7 +5480,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5448,6 +5493,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5533,7 +5579,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5569,6 +5616,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5588,6 +5636,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5631,12 +5680,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6711,8 +6762,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -10258,6 +10308,36 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-custom": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/passport-custom/-/passport-custom-1.0.5.tgz",
+      "integrity": "sha1-LR2cF0pqRoW/Aom85hCRzV7HsPQ=",
+      "requires": {
+        "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
+      "requires": {
+        "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
@@ -10318,6 +10398,11 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pbkdf2": {
       "version": "3.0.17",

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "description": "Project Danger Web Client",
   "main": "src/server/app.js",
   "scripts": {
-    "serve": "NODE_ENV=development nodemon --watch ./src/server --exec babel-node ./src/server/app.js",
+    "serve": "NODE_ENV=development nodemon --watch ./src/server --exec babel-node -r node_modules/dotenv/config ./src/server/app.js dotenv_config_path=./src/server/.env",
     "build": "NODE_ENV=production webpack --env.production --config ./config/webpack.prod.js && babel ./src/server -d dist/server --copy-files",
     "start": "NODE_ENV=production node ./dist/server/app.js",
     "babel-node": "babel-node",
@@ -58,6 +58,7 @@
     "bulma": "^0.7.2",
     "copy-webpack-plugin": "^4.6.0",
     "css-loader": "^1.0.0",
+    "dotenv": "^6.2.0",
     "dotenv-webpack": "^1.5.7",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
@@ -90,11 +91,16 @@
     "webpack-hot-middleware": "^2.24.3"
   },
   "dependencies": {
+    "axios": "^0.18.0",
+    "body-parser": "^1.18.3",
     "debug": "~2.6.9",
     "ejs": "~2.5.7",
     "express": "^4.16.4",
     "http-errors": "~1.6.2",
     "morgan": "~1.9.0",
+    "passport": "^0.4.0",
+    "passport-custom": "^1.0.5",
+    "passport-local": "^1.0.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   }

--- a/web/src/server/app.js
+++ b/web/src/server/app.js
@@ -2,6 +2,7 @@ import express, { json, urlencoded } from 'express'
 import { createServer } from 'http'
 import createError from 'http-errors'
 import { join } from 'path'
+import passport from 'passport'
 import logger from 'morgan'
 
 // Custom libraries
@@ -17,11 +18,6 @@ import billingRouter from './routes/billing'
 const app = express()
 const port = normalizePort(process.env.PORT || '3000')
 const devMode = process.env.NODE_ENV !== 'production'
-
-// Set up the routes
-app.use('/', indexRouter)
-app.use('/billing', billingRouter)
-app.use('/dashboard', dashboardRouter)
 
 // If we're in development mode, load the development Webpack config
 // and use the Webpack Express Middleware to run webpack when the server
@@ -84,6 +80,11 @@ if (devMode) {
   app.locals.bundles = bundles
 }
 
+app.use(json())
+app.use(urlencoded())
+
+app.use(passport.initialize())
+
 // Set public directory for static assets
 // NOTE – This has to be after sassMiddleware for sass compilation to work
 app.use(express.static(join(__dirname, './public')))
@@ -93,8 +94,12 @@ app.set('views', join(__dirname, 'views'))
 app.set('view engine', 'ejs')
 app.set('port', port)
 app.use(logger('dev'))
-app.use(json())
-app.use(urlencoded({ extended: false }))
+
+// Set up the routes
+app.use('/', indexRouter)
+app.use('/billing', billingRouter)
+app.use('/dashboard', dashboardRouter)
+
 
 // Server Events
 const onListening = () => {
@@ -127,9 +132,11 @@ const onError = (error) => {
 
 // error handler
 app.use((err, req, res, next) => {
+  console.info('ERROR HANDLER')
   // set locals, only providing error in development
   res.locals.message = err.message
   res.locals.error = req.app.get('env') === 'development' ? err : {}
+  console.info(err)
   // render the error page
   res.status(err.status || 500)
   res.render('error', { title: `Error`, error: err })

--- a/web/src/server/example.env
+++ b/web/src/server/example.env
@@ -1,0 +1,1 @@
+API_URL=http://api:3001

--- a/web/src/server/libs/api/index.js
+++ b/web/src/server/libs/api/index.js
@@ -1,0 +1,65 @@
+import urlLib from 'url'
+import axios from 'axios'
+
+const URL = urlLib.URL
+
+/**
+ * API Interface for the DangerAPI
+ *
+ * Note this code will not be the SDK for the DangerAPI
+ * as it does not remember credentials as it's requesting
+ * resources for a multitude of users
+ */
+
+class DangerApi {
+  constructor(opts) {
+    const url = (typeof opts === 'object') ? opts.url : opts
+
+    if (typeof (url) !== 'string' && url.length < 1) {
+      throw new Error('Must pass a url option to the DangerAPI constructor')
+    }
+
+    const baseURL = new URL('api/', url)
+
+    this.axiosInstance = axios.create({
+      baseURL: baseURL.toString(),
+      timeout: 5000
+    })
+  }
+
+  /**
+   * @param {String} resource
+   * @param {String} token
+   */
+  async request(resource, token) {
+    const res = await this.send(resource, token)
+    return res
+  }
+
+  /**
+   * Authenticates a user and returns a token
+   * @param {String} email
+   * @param {String} password
+   * @return {String} token
+   */
+  async authenticate(email, password) {
+    const res = await this.send({
+      url: 'login',
+      method: 'POST',
+      data: {
+        email,
+        password
+      }
+    })
+    console.info(res)
+    return res.token
+  }
+
+  async send(config, token) {
+    // Do whatever with token
+    return await this.axiosInstance.request(config)
+  }
+}
+
+
+export default DangerApi

--- a/web/src/server/libs/api/index.js
+++ b/web/src/server/libs/api/index.js
@@ -51,12 +51,11 @@ class DangerApi {
         password
       }
     })
-    console.info(res)
-    return res.token
+    return res.data.token
   }
 
   async send(config, token) {
-    // Do whatever with token
+    // Do whatever with token to auth future requests
     return await this.axiosInstance.request(config)
   }
 }

--- a/web/src/server/libs/auth.js
+++ b/web/src/server/libs/auth.js
@@ -1,0 +1,44 @@
+
+import passport from 'passport'
+import LocalStrategy from 'passport-local'
+
+import DangerAPI from './api'
+
+const API = new DangerAPI(process.env.API_URL)
+
+passport.serializeUser((user, done) => {
+  done(null, user.email)
+})
+
+passport.deserializeUser((id, done) => {
+  done(null, id)
+})
+
+const authUserFunc = async function(email, password, done) {
+  console.info('authUserFunc')
+  console.info(email, password)
+  let token
+  try {
+    token = await API.authenticate(email, password)
+  } catch (error) {
+    console.info('error')
+    console.info(error)
+  }
+  if (token) {
+    done(null, { email, token })
+  } else {
+    done(null, false)
+  }
+}
+
+passport.use(new LocalStrategy(
+  {
+    usernameField: 'email',
+    session: false
+  },
+  authUserFunc
+))
+
+export default {
+  loginMiddleware: passport.authenticate('local', { session: false })
+}

--- a/web/src/server/libs/auth.js
+++ b/web/src/server/libs/auth.js
@@ -15,14 +15,11 @@ passport.deserializeUser((id, done) => {
 })
 
 const authUserFunc = async function(email, password, done) {
-  console.info('authUserFunc')
-  console.info(email, password)
   let token
   try {
     token = await API.authenticate(email, password)
   } catch (error) {
-    console.info('error')
-    console.info(error)
+    console.info(error.toString())
   }
   if (token) {
     done(null, { email, token })

--- a/web/src/server/routes/index.js
+++ b/web/src/server/routes/index.js
@@ -1,6 +1,7 @@
 import express from 'express'
 import constants from '../../shared/constants'
 import { makePermalinkWithString } from '../libs/string-utilities'
+import auth from '../libs/auth'
 
 const router = express.Router()
 
@@ -15,19 +16,23 @@ const renderBundles = (req, pageTitle) => {
 }
 
 /* GET home page. */
-router.get('/', (req, res, next) => {
+router.get('/', (req, res) => {
   res.render('index', renderBundles(req, 'Home'))
 })
 
-router.get('/sign-up', (req, res, next) => {
+router.get('/sign-up', (req, res) => {
   res.render('user/sign-up', renderBundles(req, 'Sign up'))
 })
 
-router.get('/sign-in', (req, res, next) => {
+router.get('/sign-in', (req, res) => {
   res.render('user/sign-in', renderBundles(req, 'Sign in'))
 })
 
-router.get('/sign-in/password-reset', (req, res, next) => {
+router.post('/sign-in', auth.loginMiddleware, (req, res) => {
+  res.render(JSON.stringify(req.user, null, 2))
+})
+
+router.get('/sign-in/password-reset', (req, res) => {
   res.render(
     'user/password-reset',
     renderBundles(req, 'Reset password')

--- a/web/src/server/routes/index.js
+++ b/web/src/server/routes/index.js
@@ -29,7 +29,7 @@ router.get('/sign-in', (req, res) => {
 })
 
 router.post('/sign-in', auth.loginMiddleware, (req, res) => {
-  res.render(JSON.stringify(req.user, null, 2))
+  res.json(req.user)
 })
 
 router.get('/sign-in/password-reset', (req, res) => {

--- a/web/src/server/views/partials/login.ejs
+++ b/web/src/server/views/partials/login.ejs
@@ -1,4 +1,4 @@
-<form class="login-form">
+<form class="login-form" action="/sign-in" method="post">
   <div class="field">
     <label class="label is-small" for="email">Email</label>
     <div class="control">


### PR DESCRIPTION
Bunch of changes to get web logins using the API:
- .env support and handling with docker-compose and the web
- Note updated readme to copy example.env in web/src/server/
- Basic API request handler lib for the web server. This won't be our SDK as it needs to not store auth state as requests are made on behalf of a multitude of users
- Current placeholder render of the user object with the token after successful login. Figured this was a good stopping point

To avoid session management, I think we can put the token in a cookie, I'll work on that next