### PR TITLE
ability to execute sequelize commands via makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,15 @@ stop:
 test-api:
 	docker-compose build && \
 	docker-compose -f docker-compose.test.yml up --remove-orphans --exit-code-from api-testrunner
+
+# This is... wrong. But it works
+# https://stackoverflow.com/a/6273809/836205
+# Run any sequelize command in the container via `make sequelize COMMAND`
+# or leave COMMAND blank for a list of sequelize commands
+sequelize:
+	docker container exec danger-api /api/node_modules/.bin/sequelize $(filter-out $@,$(MAKECMDGOALS))
+
+# This is a catchall for sequelize commands to silence Make from complaining
+# about "No rule to Make target". See SO link above
+%:
+	@:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ cp api/example.env api/.env
 cp web/src/server/example.env web/src/server/.env
 make builddev
 make start
+make sequelize db:seed:all
 make stop
 
 // Changed a dependency in package.json?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       API_PORT: 3001
     depends_on:
       - db
+    container_name: danger-api
 
   db:
     image: postgres:11.2-alpine

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,17 @@
+## Seed Data
+
+Seed data is found in the `api/src/db/seeders` data and should be generated with sequelize
+
+To add seed data:
+`api/node_modules/.bin/sequelize seed:generate NAME`
+If sequelize is globally installed, from the api directory running `sequelize seed:generate NAME` will work
+
+The newly generated seed file can then add data as needed.
+
+## Migrations
+
+Migrations are automatically run when `make start` is invoked. If a migration has been edited, you'll need to run `make sequelize db:migrate:undo:all`, then `make sequelize db:migrate`. _Note:_ containers _must_ be running to use `make sequelize` commands!
+
+## Sequelize
+
+The Makefile is setup to execute any sequelize commands in the running API container. Run `make sequelize COMMAND` to run commands, or `make sequelize` to see a list of available commands


### PR DESCRIPTION
- Now we can sequelize all the things! The `make sequelize` command shows all the options, everything is pretty self-explanatory
- Doc with specific scenarios added for seed data and migrations