### PR TITLE
businesstime!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ stop:
 	docker-compose stop
 
 test-api:
-	docker-compose build && \
-	docker-compose -f docker-compose.test.yml up --remove-orphans --exit-code-from api-testrunner
+	docker-compose -f docker-compose.test.yml up --build --remove-orphans --exit-code-from api-testrunner
 
 # This is... wrong. But it works
 # https://stackoverflow.com/a/6273809/836205

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -6764,6 +6764,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "ono": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-5.0.1.tgz",
+      "integrity": "sha512-4/4BPGHX8OuDDNx1SrOqTOI7zajPjvBvrG1jDG3hDq4qBpoKlzG2d83Vdz26hvv0FFWYsLdHf+1Vu/k2d8Ww9w=="
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "express": "^4.16.4",
     "joi": "^14.3.1",
     "jsonwebtoken": "^8.4.0",
+    "ono": "^5.0.1",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -8,6 +8,7 @@
     "start": "NODE_ENV=production node ./dist/server.js",
     "babel-node": "babel-node",
     "test": "jest",
+    "test-u": "jest 'src/.*\\.test-(u)\\.js$'",
     "lint": "eslint src",
     "migrate": "sequelize db:migrate",
     "seed": "sequelize db:seed:all"

--- a/api/src/businesstime/__mocks__/user.js
+++ b/api/src/businesstime/__mocks__/user.js
@@ -1,0 +1,4 @@
+export default {
+  findByEmail: jest.fn(() => ({ email: 'not-a-real-email@email.com', password: 'not-a-real-hashed-password' })),
+  updateByEmail: jest.fn(() => ({ email: 'not-a-real-email@email.com', password: 'not-a-real-hashed-password' }))
+}

--- a/api/src/businesstime/project.js
+++ b/api/src/businesstime/project.js
@@ -14,9 +14,9 @@ async function findAll(id) {
   return await db.model(MODEL_NAME).findAll({}, { raw: true })
 }
 
-async function create(fields) {
+async function create(body) {
   const db = getDb()
-  return await db.model(MODEL_NAME).create(fields, { raw: true })
+  return await db.model(MODEL_NAME).create(body, { raw: true })
 }
 
 export default {

--- a/api/src/businesstime/project.js
+++ b/api/src/businesstime/project.js
@@ -1,0 +1,26 @@
+import { getDb } from '../db/db-connector'
+
+const MODEL_NAME = 'Project'
+
+async function findById(id) {
+  const db = getDb()
+  const project = await db.model(MODEL_NAME).findOne({ where: { id } })
+
+  return project && project.get({ plain: true })
+}
+
+async function findAll(id) {
+  const db = getDb()
+  return await db.model(MODEL_NAME).findAll({}, { raw: true })
+}
+
+async function create(fields) {
+  const db = getDb()
+  return await db.model(MODEL_NAME).create(fields, { raw: true })
+}
+
+export default {
+  findById,
+  findAll,
+  create
+}

--- a/api/src/businesstime/user.js
+++ b/api/src/businesstime/user.js
@@ -1,8 +1,10 @@
 import { getDb } from '../db/db-connector'
 
+const MODEL_NAME = 'User'
+
 async function findByEmail(email) {
   const db = getDb()
-  const user = await db.model('User').findOne({ where: { email } })
+  const user = await db.model(MODEL_NAME).findOne({ where: { email } })
 
   return user && user.get({ plain: true })
 }

--- a/api/src/businesstime/user.js
+++ b/api/src/businesstime/user.js
@@ -1,24 +1,12 @@
 import { getDb } from '../db/db-connector'
-import passwords from '../libs/passwords'
 
 async function findByEmail(email) {
   const db = getDb()
   const user = await db.model('User').findOne({ where: { email } })
-  return user
-}
 
-async function setPassword(user, password) {
-  const hashedPassword = await passwords.generateHash(password)
-  user.set('password', hashedPassword)
-}
-
-async function validatePassword(user, password) {
-  const valid = await passwords.validatePassword(password, user.get('password'))
-  return valid
+  return user && user.get({ plain: true })
 }
 
 export default {
-  findByEmail,
-  setPassword,
-  validatePassword
+  findByEmail
 }

--- a/api/src/businesstime/user.js
+++ b/api/src/businesstime/user.js
@@ -1,4 +1,5 @@
 import { getDb } from '../db/db-connector'
+import ono from 'ono'
 
 const MODEL_NAME = 'User'
 
@@ -9,6 +10,17 @@ async function findByEmail(email) {
   return user && user.get({ plain: true })
 }
 
+async function updateByEmail(email, body) {
+  const db = getDb()
+
+  const user = await db.model(MODEL_NAME).findOne({ where: { email } })
+
+  if (!user) throw ono({ code: 404 }, `Cannot update, user not found with email: ${email}`)
+
+  return await user.update(body, { raw: true })
+}
+
 export default {
-  findByEmail
+  findByEmail,
+  updateByEmail,
 }

--- a/api/src/controllers/loader.js
+++ b/api/src/controllers/loader.js
@@ -16,7 +16,7 @@ const UNAUTHENTICATED_CONTROLLERS = {
 }
 
 const loadControllers = (router, controllers, middleware) => {
-  Object.keys(controllers).forEach(path => {
+  Object.keys(controllers).forEach((path) => {
     const controllerFileName = controllers[path]
     const controller = require(`./${controllerFileName}`).default
     const controllerRouter = express.Router()
@@ -29,7 +29,7 @@ const loadControllers = (router, controllers, middleware) => {
   })
 }
 
-const loader = router => {
+const loader = (router) => {
   loadControllers(router, AUTHENTICATED_CONTROLLERS, [
     auth.jwtMiddleware
   ])

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -8,7 +8,7 @@ const loginController = function(router) {
 }
 
 const login = function(req, res) {
-  const token = tokenIntegrator.generateToken(req.user.get('email'))
+  const token = tokenIntegrator.generateToken(req.user.email)
   res.json({
     token
   })

--- a/api/src/controllers/projects.js
+++ b/api/src/controllers/projects.js
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 import validate from '../libs/payloadValidation'
-import { getDb } from '../db/db-connector'
+import BusinessProject from '../businesstime/project'
+import ono from 'ono'
 
 const projectsPayloadSchema = Joi.compile({
   body: Joi.object().keys({
@@ -8,54 +9,48 @@ const projectsPayloadSchema = Joi.compile({
   })
 })
 
-const projectController = function(router) {
+const projectsController = function(router) {
   router.post('/', validate(projectsPayloadSchema), addProject)
   router.get('/', getProjects)
   router.get('/:id', getProject)
 }
 
 const getProjects = async function(req, res) {
-  const db = getDb()
-  let projects
   try {
-    projects = await db.model('Project').findAll({}, { raw: true })
+    const projects = await BusinessProject.findAll()
+    throw new Error('blarp')
     res.json(projects)
   } catch (e) {
-    console.error(e)
-    res.status(500).json({ error: 'Cannot fetch projects' })
+    console.error(e.stack)
+    res.status(e.code || 500).json({ error: 'Cannot fetch projects' })
   }
 }
 
 const getProject = async function(req, res) {
   const id = req.params.id
-  const db = getDb()
-  let project
+
   try {
-    project = await db
-      .model('Project')
-      .findOne({ where: { id } }, { raw: true })
+    const project = await BusinessProject.findById(id)
+    if (!project) throw ono({ code: 404 }, `No project with id ${id}`)
+    res.json(project)
   } catch (e) {
-    console.error(e)
+    console.error(e.stack)
     res
-      .status(500)
+      .status(e.code || 500)
       .json({ error: `error fetching project with id ${id}` })
   }
-  res.json(project)
 }
 
 const addProject = async function(req, res) {
-  const db = getDb()
   const { name } = req.body
-  let project
+
   try {
-    project = await db
-      .model('Project')
-      .create({ name }, { raw: true })
-    res.json(project)
+    const project = await BusinessProject.create({ name })
+    res.status(201).json(project)
   } catch (e) {
-    console.error(e)
-    res.status(500).json({ error: 'Cannot create project' })
+    console.error(e.stack)
+    res.status(e.code || 500).json({ error: 'Cannot create project' })
   }
 }
 
-export default projectController
+export default projectsController

--- a/api/src/controllers/projects.js
+++ b/api/src/controllers/projects.js
@@ -18,7 +18,6 @@ const projectsController = function(router) {
 const getProjects = async function(req, res) {
   try {
     const projects = await BusinessProject.findAll()
-    throw new Error('blarp')
     res.json(projects)
   } catch (e) {
     console.error(e.stack)

--- a/api/src/coordinators/billing.test-u.js
+++ b/api/src/coordinators/billing.test-u.js
@@ -10,7 +10,7 @@ describe('billing coordinator', () => {
     const email = 'test@bonkeybong.com'
     let resolvedValue
 
-    beforeAll(async () => {
+    beforeAll(async() => {
       resolvedValue = await billingCoordinator.subscribeCustomerToPlan(
         {
           token,

--- a/api/src/coordinators/user.js
+++ b/api/src/coordinators/user.js
@@ -1,0 +1,24 @@
+import passwords from '../libs/passwords'
+import userBusiness from '../businesstime/user'
+
+async function updatePassword(password) {
+  const hashedPassword = await passwords.generateHash(password)
+  await userBusiness.update({ password: hashedPassword })
+}
+
+async function validateEmailPasswordCombo(email, password) {
+  const user = await userBusiness.findByEmail(email)
+
+  if (!user) throw new Error(`No user found with email: ${email}`)
+
+  const valid = await passwords.validatePassword(password, user.password)
+
+  if (!valid) throw new Error(`Invalid Email/Password combination for email: ${email}`)
+
+  return user
+}
+
+export default {
+  updatePassword,
+  validateEmailPasswordCombo
+}

--- a/api/src/coordinators/user.js
+++ b/api/src/coordinators/user.js
@@ -1,14 +1,14 @@
 import passwords from '../libs/passwords'
-import userBusiness from '../businesstime/user'
+import BusinessUser from '../businesstime/user'
 import ono from 'ono'
 
-async function updatePassword(password) {
+async function updatePassword(email, password) {
   const hashedPassword = await passwords.generateHash(password)
-  await userBusiness.update({ password: hashedPassword })
+  await BusinessUser.updateByEmail(email, { password: hashedPassword })
 }
 
 async function validateEmailPasswordCombo(email, password) {
-  const user = await userBusiness.findByEmail(email)
+  const user = await BusinessUser.findByEmail(email)
 
   if (!user) throw ono(`No user found with email: ${email}`)
 

--- a/api/src/coordinators/user.js
+++ b/api/src/coordinators/user.js
@@ -1,5 +1,6 @@
 import passwords from '../libs/passwords'
 import userBusiness from '../businesstime/user'
+import ono from 'ono'
 
 async function updatePassword(password) {
   const hashedPassword = await passwords.generateHash(password)
@@ -9,11 +10,11 @@ async function updatePassword(password) {
 async function validateEmailPasswordCombo(email, password) {
   const user = await userBusiness.findByEmail(email)
 
-  if (!user) throw new Error(`No user found with email: ${email}`)
+  if (!user) throw ono(`No user found with email: ${email}`)
 
   const valid = await passwords.validatePassword(password, user.password)
 
-  if (!valid) throw new Error(`Invalid Email/Password combination for email: ${email}`)
+  if (!valid) throw ono(`Invalid Email/Password combination for email: ${email}`)
 
   return user
 }

--- a/api/src/coordinators/user.js
+++ b/api/src/coordinators/user.js
@@ -10,11 +10,11 @@ async function updatePassword(email, password) {
 async function validateEmailPasswordCombo(email, password) {
   const user = await BusinessUser.findByEmail(email)
 
-  if (!user) throw ono(`No user found with email: ${email}`)
+  if (!user) throw ono({ code: 404 }, `No user found with email: ${email}`)
 
   const valid = await passwords.validatePassword(password, user.password)
 
-  if (!valid) throw ono(`Invalid Email/Password combination for email: ${email}`)
+  if (!valid) throw ono({ code: 401 }, `Invalid Email/Password combination for email: ${email}`)
 
   return user
 }

--- a/api/src/coordinators/user.test-u.js
+++ b/api/src/coordinators/user.test-u.js
@@ -1,0 +1,54 @@
+import userCoordinator from './user'
+import BusinessUser from '../businesstime/user'
+import passwords from '../libs/passwords'
+
+jest.mock('../businesstime/user')
+jest.mock('../libs/passwords')
+
+describe('user coordinator', () => {
+  const email = 'hughjackman@johntravolta.gov'
+  const password = 'swordfish'
+
+  describe('#updatePassword', () => {
+    beforeAll(async() => {
+      await userCoordinator.updatePassword(email, password)
+    })
+
+    it('should call passwords.generateHash with the correct password', () => {
+      expect(passwords.generateHash.mock.calls.length).toBe(1)
+      expect(passwords.generateHash.mock.calls[0][0]).toBe(password)
+    })
+
+    it('should call BusinessUser.updateByEmail with the correct email and body', () => {
+      const mockHashedPassword = passwords.generateHash.mock.results[0].value
+      expect(BusinessUser.updateByEmail.mock.calls.length).toBe(1)
+      expect(BusinessUser.updateByEmail.mock.calls[0][0]).toBe(email)
+      expect(BusinessUser.updateByEmail.mock.calls[0][1]).toEqual({ password: mockHashedPassword })
+    })
+  })
+
+  describe('validateEmailPasswordCombo', () => {
+    let returnVal
+
+    beforeAll(async() => {
+      returnVal = await userCoordinator.validateEmailPasswordCombo(email, password)
+    })
+
+    it('should call BusinessUser.findByEmail with the correct email', () => {
+      expect(BusinessUser.findByEmail.mock.calls.length).toBe(1)
+      expect(BusinessUser.findByEmail.mock.calls[0][0]).toBe(email)
+    })
+
+    it('should call passwords.validatePassword with the correct email and password', () => {
+      const mockUser = BusinessUser.findByEmail.mock.results[0].value
+      expect(passwords.validatePassword.mock.calls.length).toBe(1)
+      expect(passwords.validatePassword.mock.calls[0][0]).toBe(password)
+      expect(passwords.validatePassword.mock.calls[0][1]).toBe(mockUser.password)
+    })
+
+    it('should return the user object', () => {
+      const mockUser = BusinessUser.findByEmail.mock.results[0].value
+      expect(returnVal).toEqual(mockUser)
+    })
+  })
+})

--- a/api/src/libs/__mocks__/passwords.js
+++ b/api/src/libs/__mocks__/passwords.js
@@ -1,0 +1,4 @@
+export default {
+  generateHash: jest.fn(() => 'not-a-real-hash'),
+  validatePassword: jest.fn(() => true)
+}

--- a/api/src/libs/passportLocal.js
+++ b/api/src/libs/passportLocal.js
@@ -1,5 +1,6 @@
 import { Strategy as LocalStrategy } from 'passport-local'
 import UserCoordinator from '../coordinators/user'
+import ono from 'ono'
 
 const options = {
   session: false,
@@ -14,7 +15,7 @@ export default function(passport) {
       try {
         user = await UserCoordinator.validateEmailPasswordCombo(email, password)
       } catch (err) {
-        done(new Error(`Invalid user/pass ${email}`))
+        done(ono(err, `Invalid user/pass ${email}`))
       }
 
       console.info('logging in ' + email)

--- a/api/src/libs/passportLocal.js
+++ b/api/src/libs/passportLocal.js
@@ -1,5 +1,5 @@
 import { Strategy as LocalStrategy } from 'passport-local'
-import BusinessUser from '../businesstime/user'
+import UserCoordinator from '../coordinators/user'
 
 const options = {
   session: false,
@@ -9,18 +9,16 @@ const options = {
 export default function(passport) {
   passport.use(
     new LocalStrategy(options, async(email, password, done) => {
-      const user = await BusinessUser.findByEmail(email)
-      if (!user) {
+      let user
+
+      try {
+        user = await UserCoordinator.validateEmailPasswordCombo(email, password)
+      } catch (err) {
         done(new Error(`Invalid user/pass ${email}`))
       }
-      const validPassword = await BusinessUser.validatePassword(user, password)
 
-      if (validPassword) {
-        console.info('logging in ' + email)
-        return done(null, user)
-      } else {
-        return done(new Error(`Invalid user/pass ${email}`))
-      }
+      console.info('logging in ' + email)
+      return done(null, user)
     })
   )
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,7 +19,6 @@ services:
 
   db-test:
     image: postgres:11.2-alpine
-    restart: always
     environment:
       POSTGRES_DB: test
       POSTGRES_USER: bonkey


### PR DESCRIPTION
- moves user and project fetching/creation to businesstime layer
- moves user password functions to coordinator layer since this is touching the user model and also accessing the password generator/validator
- adds ono library for Error creation, which allows us to easily set error.code property anywhere in code, and then send that status to the api consumer.  Also allows us to re-throw errors with updated messages/data without losing stack trace
- All data coming out of BusinessTime :tm: are now POJOs