### PR TITLE
Docker updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,3 @@ typings/
 
 # next.js build output
 .next
-
-# Dev database data
-.postgres-data/

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,19 @@ build:
 	./build.sh
 
 builddev:
-	./build.sh && docker-compose build
+	docker-compose build
 
 rebuilddev:
-	docker-compose down && ./build.sh && docker-compose build --no-cache
+	docker-compose down && docker volume rm project-danger_postgres-data && docker-compose build --no-cache
+
+installweb:
+	docker-compose exec web npm install
+
+installapi:
+	docker-compose exec api npm install
 
 cleardev:
-	docker-compose down
+	docker-compose down && docker volume rm project-danger_postgres-data
 
 start:
 	docker-compose up

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ cp api/example.env api/.env
 cp web/src/server/example.env web/src/server/.env
 make builddev
 make start
-make sequelize db:seed:all
+make sequelize db:seed:all # Run in a separate shell _while_ app is running
 make stop
 ```
 
 #### Changed a dependency in package.json?
+While the app is running in docker (make start), run:
 ```
-make rebuilddev
-make start
+make install[service] # Service is "web" or "api" (eg "make installweb")
 ```
 
 ## Production

--- a/api/Dockerfile-dev
+++ b/api/Dockerfile-dev
@@ -1,5 +1,0 @@
-FROM danger/api:latest
-
-ENV NODE_ENV development
-
-RUN npm install

--- a/api/Dockerfile-prod
+++ b/api/Dockerfile-prod
@@ -18,4 +18,15 @@ RUN npm install
 # .dockerignore ensures not everything is copied
 COPY . .
 
+RUN npm run build
+
+RUN rm -rf node_modules/
+RUN rm -rf src/
+
+ENV NODE_ENV production
+RUN npm install --only=production
+
+# Delete any tar or other files npm may have cached during install
+RUN npm cache clean --force
+
 ENTRYPOINT ["/bin/sh", "./run.sh"]

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -3273,7 +3273,8 @@
     "faker": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -3497,8 +3498,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3522,15 +3522,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3547,22 +3545,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3693,8 +3688,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3708,7 +3702,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3725,7 +3718,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3734,15 +3726,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3763,7 +3753,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3852,8 +3841,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3867,7 +3855,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3963,8 +3950,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4006,7 +3992,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4028,7 +4013,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4077,15 +4061,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/api/run.sh
+++ b/api/run.sh
@@ -13,4 +13,7 @@ case $1 in
     npm run migrate
     npm run serve
     ;;
+  *)
+    exec "$@"
+    ;;
 esac

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
-docker build -t danger/web web/
-docker build -t danger/api api/
+docker build -t bonkeybong/project_danger_web -f web/Dockerfile-prod web/
+docker build -t bonkeybong/project_danger_api -f api/Dockerfile-prod api/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,6 @@ services:
   api-testrunner:
     build:
       context: ./api
-      dockerfile: Dockerfile-dev
     volumes:
       - ./api:/api
       - /api/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
   web:
     build:
       context: ./web
-      dockerfile: Dockerfile-dev
     volumes:
       - ./web:/web
       - /web/node_modules
@@ -17,11 +16,11 @@ services:
       - ./web/src/server/.env
     environment:
       NODE_ENV: development
+    container_name: danger-web
 
   api:
     build:
       context: ./api
-      dockerfile: Dockerfile-dev
     volumes:
       - ./api:/api
       - /api/node_modules
@@ -47,6 +46,8 @@ services:
       POSTGRES_USER: bonkey
       POSTGRES_PASSWORD: bong
     volumes:
-      - ./.postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
     ports:
       - 5432:5432
+volumes:
+  postgres-data:

--- a/docs/data.md
+++ b/docs/data.md
@@ -15,3 +15,9 @@ Migrations are automatically run when `make start` is invoked. If a migration ha
 ## Sequelize
 
 The Makefile is setup to execute any sequelize commands in the running API container. Run `make sequelize COMMAND` to run commands, or `make sequelize` to see a list of available commands
+
+## Erase Database and Start Over
+
+`make cleardev`
+OR
+`make rebuilddev`

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,6 +3,7 @@ FROM node:10.15.1-alpine
 
 # The base node image sets a very verbose log level.
 ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV development
 
 WORKDIR /web
 
@@ -12,13 +13,5 @@ COPY package*.json ./
 RUN npm install
 
 COPY . .
-
-RUN npm run build
-RUN rm -rf node_modules/
-RUN rm -rf src/
-RUN rm -rf config/
-
-ENV NODE_ENV production
-RUN npm install --only=production
 
 ENTRYPOINT ["/bin/sh", "./run.sh"]

--- a/web/Dockerfile-dev
+++ b/web/Dockerfile-dev
@@ -1,5 +1,0 @@
-FROM danger/web:latest
-
-ENV NODE_ENV development
-
-RUN npm install

--- a/web/Dockerfile-prod
+++ b/web/Dockerfile-prod
@@ -1,0 +1,26 @@
+FROM node:10.15.1-alpine
+
+# The base node image sets a very verbose log level.
+ENV NPM_CONFIG_LOGLEVEL warn
+
+WORKDIR /web
+
+# Only copy package.json first to take advantage of docker caching
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+RUN rm -rf node_modules/
+RUN rm -rf src/
+RUN rm -rf config/
+
+ENV NODE_ENV production
+RUN npm install --only=production
+
+# Delete any tar or other files npm may have cached during install
+RUN npm cache clean --force
+
+ENTRYPOINT ["/bin/sh", "./run.sh"]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5397,8 +5397,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5422,15 +5421,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5447,22 +5444,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5593,8 +5587,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5608,7 +5601,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5625,7 +5617,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5634,15 +5625,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5663,7 +5652,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5752,8 +5740,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5767,7 +5754,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5863,8 +5849,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5906,7 +5891,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5928,7 +5912,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5977,15 +5960,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8816,7 +8797,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.12.1",
@@ -9576,6 +9558,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -10359,7 +10342,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -11825,6 +11809,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
@@ -12029,6 +12014,7 @@
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
       "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -12040,6 +12026,7 @@
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
       "integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -12899,6 +12886,7 @@
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
       "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/web/package.json
+++ b/web/package.json
@@ -80,6 +80,8 @@
     "postcss-loader": "^3.0.0",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4",
     "react-redux": "^6.0.0",
     "react-router-dom": "^4.3.1",
     "react-select": "^2.4.2",
@@ -112,8 +114,6 @@
     "passport": "^0.4.0",
     "passport-custom": "^1.0.5",
     "passport-jwt": "^4.0.0",
-    "passport-local": "^1.0.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "passport-local": "^1.0.0"
   }
 }

--- a/web/run.sh
+++ b/web/run.sh
@@ -11,4 +11,10 @@ case $1 in
   devstart)
     npm run serve
     ;;
+  install)
+    npm install
+    ;;
+  *)
+    exec "$@"
+    ;;    
 esac


### PR DESCRIPTION
Lots of Docker updates based around improving the dev experience and creating a better test/deploy setup for CI

- Expose `npm install` commands
- Separates dev and production Dockerfiles because we don't have a canonical repository name for them yet and can't build one image from a second one, so integrating with Docker repos and CI/CD is problematic
- Open up the entrypoint in each Docker container to run any shell script
- Cleanup web package.json to separate web server production required modules vs. production _build_ modules. Build has to be a dev dependency unfortunately, unless we create a separate package for just the build
- Move database volume to a named volume. It's cleaner than binding to a local directory since we're not doing anything with the database data locally (we can copy the data out of the named volume if we ever want to)

Backlog items to consider:
- custom CLI tool to manage the local environment/docker. A Makefile is not the appropriate tool, it's really for creating a build artifact, not interacting with an environment, managing state etc.