### PR TITLE
Force validation of all fields to PUT/POST to whitelist update fields

### DIFF
--- a/api/src/controllers/organizations.js
+++ b/api/src/controllers/organizations.js
@@ -4,9 +4,7 @@ import BusinessOrganization from '../businesstime/organization'
 import ono from 'ono'
 
 const organizationsPayloadSchema = Joi.compile({
-  body: Joi.object().keys({
-    name: Joi.string().required()
-  })
+  name: Joi.string().required()
 })
 
 const organizationsController = function(router) {
@@ -23,9 +21,7 @@ const getOrganization = async function(req, res) {
     res.json(org)
   } catch (e) {
     console.error(e.stack)
-    res
-      .status(e.code || 500)
-      .json({ error: `error fetching organization with id ${id}` })
+    res.status(e.code || 500).json({ error: `error fetching organization with id ${id}` })
   }
 }
 

--- a/api/src/controllers/projects.js
+++ b/api/src/controllers/projects.js
@@ -11,10 +11,8 @@ const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
 )
 
 const projectsPayloadSchema = Joi.compile({
-  body: Joi.object().keys({
-    name: Joi.string().required(),
-    description: Joi.string().allow('')
-  })
+  name: Joi.string().required(),
+  description: Joi.string().allow('')
 })
 
 const projectsController = function(router) {
@@ -50,7 +48,6 @@ const getProject = async function(req, res) {
 
 const addProject = async function(req, res) {
   const { body } = req
-  // Overwrite orgId even if they passed anything in
   body.orgId = req.requestorInfo.orgId
 
   try {
@@ -66,7 +63,7 @@ const replaceProject = async function(req, res) {
   const { id } = req.params
   const { body } = req
 
-  // TODO: don't let users change orgId
+  body.orgId = req.requestorInfo.orgId
 
   try {
     const project = await BusinessProject.updateById(id, body)

--- a/api/src/controllers/signup.js
+++ b/api/src/controllers/signup.js
@@ -6,17 +6,15 @@ import userCoordinator from '../coordinators/user'
 import auth from '../libs/auth'
 
 const signupPayloadSchema = Joi.compile({
-  body: Joi.object().keys({
-    firstName: Joi.string().required(),
-    lastName: Joi.string().required(),
-    email: Joi.string().email().required()
-  })
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+  email: Joi.string()
+    .email()
+    .required()
 })
 
 const initialPasswordPayloadSchema = Joi.compile({
-  body: Joi.object().keys({
-    password: Joi.string().required()
-  })
+  password: Joi.string().required()
 })
 
 const signupController = function(router) {

--- a/api/src/libs/middleware/payloadValidation.js
+++ b/api/src/libs/middleware/payloadValidation.js
@@ -1,10 +1,14 @@
 import Joi from 'joi'
 
-export default function validate(schema) {
+// Assumes validation occurs on req.body
+export default function validate(schema, options = {}) {
+  const defaultOptions = {
+    allowUnknown: false
+  }
+
+  const mergedOptions = Object.assign(defaultOptions, options)
   return (req, res, next) => {
-    const { error } = Joi.validate(req, schema, {
-      allowUnknown: true
-    })
+    const { error } = Joi.validate(req.body, schema, mergedOptions)
 
     if (!error) {
       return next()

--- a/web/src/client/js/components/ProjectForm/ProjectCreatorContainer.js
+++ b/web/src/client/js/components/ProjectForm/ProjectCreatorContainer.js
@@ -24,9 +24,8 @@ const ProjectCreatorContainer = ({ history }) => {
       createProject(
         {
           name: formValues.projectName,
-          description: formValues.projectDescription,
-          teamMemberIds: selectedUsers,
-          orgId: currentUser.orgId
+          description: formValues.projectDescription
+          // teamMemberIds: selectedUsers // TODO: when endpoint support has this, add back
         },
         history
       )


### PR DESCRIPTION
- updates payloadValidation middleware to, by default, not allow unknown fields (with option to override if needed)
- payloadValidation now always validates req.body (can update to allow validating other stuff later if needed)
- orgId manually assigned in controller on project create or edit. Not sure if there's a better way to handle this? Since we're always forcing orgs, having the user send an orgId seems unnecessary, and saves us having to validate the orgId they sent is actually the orgId they belong to
- On web, commented out submission of team members to project create. I'm guessing that will likely be a separate endpoint, but it can submit through one form