### PR TITLE
shorter field urls

### DIFF
--- a/api/src/businesstime/document.js
+++ b/api/src/businesstime/document.js
@@ -7,17 +7,13 @@ async function createForProject(projectId, body) {
   const db = getDb()
   const { orgId } = body
 
-  if (projectId !== body.projectId) {
-    throw ono({ code: 400 }, `Cannot create, project id param does not match projectId in body`)
-  }
-
   const project = await db.model('Project').findOne({ where: { id: projectId, orgId } })
 
   if (!project) {
     throw ono({ code: 404 }, `Cannot create document, project not found with id: ${projectId}`)
   }
 
-  const createdDocument = await db.model(MODEL_NAME).create(body)
+  const createdDocument = await db.model(MODEL_NAME).create({ ...body, projectId })
   return createdDocument.get({ plain: true })
 }
 
@@ -33,10 +29,6 @@ async function findByIdForProject(id, projectId, orgId) {
 
 async function updateByIdForProject(id, projectId, orgId, body) {
   const db = getDb()
-
-  if (projectId !== body.projectId) {
-    throw ono({ code: 400 }, `Cannot update, project id param does not match projectId in body`)
-  }
 
   const document = await db.model(MODEL_NAME).findOne({ where: { id, projectId, orgId } })
 

--- a/api/src/businesstime/document.js
+++ b/api/src/businesstime/document.js
@@ -47,10 +47,21 @@ async function deleteByIdForProject(id, projectId, orgId) {
   await document.destroy()
 }
 
+async function findParentProjectByDocumentId(id, orgId) {
+  const db = getDb()
+
+  const document = await db
+    .model(MODEL_NAME)
+    .findOne({ where: { id, orgId }, include: [{ model: db.model('Project') }] })
+
+  return document.Project && document.Project.get({ plain: true })
+}
+
 export default {
   createForProject,
   updateByIdForProject,
   findByIdForProject,
   findAllForProject,
-  deleteByIdForProject
+  deleteByIdForProject,
+  findParentProjectByDocumentId
 }

--- a/api/src/businesstime/document.test-i.js
+++ b/api/src/businesstime/document.test-i.js
@@ -197,6 +197,7 @@ describe('BusinessDocument', () => {
     let factoryDocument
 
     beforeAll(async () => {
+      await clearDb()
       const factoryDocuments = await DocumentFactory.createMany(1, { projectId: factoryProject.id })
       factoryDocument = factoryDocuments[0]
     })
@@ -231,6 +232,30 @@ describe('BusinessDocument', () => {
           constants.ORG_ID_2
         )
       ).rejects.toThrow()
+    })
+  })
+
+  describe('#findParentProjectByDocumentId', () => {
+    let factoryDocument
+    let project
+
+    beforeAll(async () => {
+      await clearDb()
+      const factoryProjects = await ProjectFactory.createMany(1)
+      factoryProject = factoryProjects[0]
+      const factoryDocuments = await DocumentFactory.createMany(1, {
+        projectId: factoryProject.id
+      })
+      factoryDocument = factoryDocuments[0]
+
+      project = await BusinessDocument.findParentProjectByDocumentId(
+        factoryDocument.id,
+        constants.ORG_ID
+      )
+    })
+
+    it('should return the parent project of passed in document', () => {
+      expect(project.id).toEqual(factoryProject.id)
     })
   })
 })

--- a/api/src/businesstime/document.test-i.js
+++ b/api/src/businesstime/document.test-i.js
@@ -36,18 +36,7 @@ describe('BusinessDocument', () => {
     describe('when the parent project does not exist', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessDocument.createForProject(factoryProject.id, { ...documentBody, projectId: 0 })
-        ).rejects.toThrow()
-      })
-    })
-
-    describe('when the passed in projectId does not match the body projectId', () => {
-      it('should throw an error', async () => {
-        await expect(
-          BusinessDocument.createForProject(factoryProject.id, {
-            ...documentBody,
-            projectId: 0
-          })
+          BusinessDocument.createForProject(0, { ...documentBody })
         ).rejects.toThrow()
       })
     })
@@ -110,17 +99,6 @@ describe('BusinessDocument', () => {
       it('should throw an error', async () => {
         await expect(
           BusinessDocument.updateByIdForProject(factoryDocument.id, projectId, 0, updateBody)
-        ).rejects.toThrow()
-      })
-    })
-
-    describe('when the passed in projectId does not match the body projectId', () => {
-      it('should throw an error', async () => {
-        await expect(
-          BusinessDocument.updateByIdForProject(factoryDocument.id, projectId, orgId, {
-            ...updateBody,
-            projectId: 0
-          })
         ).rejects.toThrow()
       })
     })

--- a/api/src/businesstime/field.js
+++ b/api/src/businesstime/field.js
@@ -17,22 +17,15 @@ const PUBLIC_FIELDS = [
   'order'
 ]
 
-async function createForProjectDocument(projectId, docId, body) {
+async function createForDocument(docId, body) {
   const db = getDb()
   const { orgId } = body
-
-  if (projectId !== body.projectId) {
-    throw ono(
-      { code: 400 },
-      `Cannot create field, project id param does not match projectId in body`
-    )
-  }
 
   if (docId !== body.docId) {
     throw ono({ code: 400 }, `Cannot create field, document id param does not match docId in body`)
   }
 
-  const document = await db.model('Document').findOne({ where: { id: docId, projectId, orgId } })
+  const document = await db.model('Document').findOne({ where: { id: docId, orgId } })
 
   if (!document) {
     throw ono({ code: 404 }, `Cannot create field, document not found with id: ${docId}`)
@@ -73,7 +66,7 @@ async function findByIdForDocument(id, docId, orgId) {
   return Object.assign({}, ...PUBLIC_FIELDS.map(key => ({ [key]: plainField[key] })))
 }
 
-async function updateByIdForProjectDocument(id, projectId, docId, orgId, body) {
+async function updateByIdForDocument(id, docId, orgId, body) {
   const db = getDb()
 
   if (docId !== body.docId) {
@@ -85,7 +78,7 @@ async function updateByIdForProjectDocument(id, projectId, docId, orgId, body) {
 
   const document = await db
     .model('Document')
-    .findOne({ where: { id: docId, projectId, orgId }, raw: true })
+    .findOne({ where: { id: docId, orgId }, raw: true })
 
   if (!document) {
     throw ono({ code: 404 }, `Cannot update field, document not found with id: ${docId}`)
@@ -118,8 +111,8 @@ function getInclude(db) {
 }
 
 export default {
-  createForProjectDocument,
-  updateByIdForProjectDocument,
+  createForDocument,
+  updateByIdForDocument,
   findByIdForDocument,
   findAllForDocument,
   deleteByIdForDocument

--- a/api/src/businesstime/field.test-i.js
+++ b/api/src/businesstime/field.test-i.js
@@ -17,7 +17,7 @@ describe('BusinessField', () => {
     factoryDocument = factoryDocuments[0]
   })
 
-  describe('#createForProjectDocument', () => {
+  describe('#createForDocument', () => {
     const fieldBody = {
       name: 'test-field',
       orgId: constants.ORG_ID,
@@ -26,9 +26,8 @@ describe('BusinessField', () => {
     let field
 
     beforeAll(async () => {
-      field = await BusinessField.createForProjectDocument(factoryProject.id, factoryDocument.id, {
+      field = await BusinessField.createForDocument(factoryDocument.id, {
         ...fieldBody,
-        projectId: factoryProject.id,
         docId: factoryDocument.id
       })
     })
@@ -42,22 +41,9 @@ describe('BusinessField', () => {
     describe('when the parent document does not exist', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessField.createForProjectDocument(factoryProject.id, factoryDocument.id, {
+          BusinessField.createForDocument(factoryDocument.id, {
             ...fieldBody,
-            projectId: factoryProject.id,
             docId: 0
-          })
-        ).rejects.toThrow()
-      })
-    })
-
-    describe('when the passed in projectId does not match the body projectId', () => {
-      it('should throw an error', async () => {
-        await expect(
-          BusinessField.createForProjectDocument(factoryProject.id, factoryDocument.id, {
-            ...fieldBody,
-            projectId: 0,
-            docId: factoryDocument.id
           })
         ).rejects.toThrow()
       })
@@ -66,9 +52,8 @@ describe('BusinessField', () => {
     describe('when the passed in docId does not match the body docId', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessField.createForProjectDocument(factoryProject.id, factoryDocument.id, {
+          BusinessField.createForDocument(factoryDocument.id, {
             ...fieldBody,
-            projectId: factoryProject.id,
             docId: 0
           })
         ).rejects.toThrow()
@@ -76,11 +61,10 @@ describe('BusinessField', () => {
     })
   })
 
-  describe('#updateByIdForProjectDocument', () => {
+  describe('#updateByIdForDocument', () => {
     let factoryField
     let fieldId
     let orgId
-    let projectId
     let docId
 
     const updateBody = {
@@ -92,7 +76,6 @@ describe('BusinessField', () => {
       factoryField = factoryFields[0]
       fieldId = factoryField.id
       orgId = factoryField.orgId
-      projectId = factoryProject.id
       docId = factoryField.docId
     })
 
@@ -100,9 +83,8 @@ describe('BusinessField', () => {
       let updatedField
 
       beforeAll(async () => {
-        updatedField = await BusinessField.updateByIdForProjectDocument(
+        updatedField = await BusinessField.updateByIdForDocument(
           factoryField.id,
-          projectId,
           docId,
           orgId,
           {
@@ -121,7 +103,7 @@ describe('BusinessField', () => {
     describe('when the target field is not found', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessField.updateByIdForProjectDocument(0, projectId, docId, orgId, updateBody)
+          BusinessField.updateByIdForDocument(0, docId, orgId, updateBody)
         ).rejects.toThrow()
       })
     })
@@ -129,7 +111,7 @@ describe('BusinessField', () => {
     describe('when the target document is not found', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessField.updateByIdForProjectDocument(fieldId, projectId, 0, orgId, updateBody)
+          BusinessField.updateByIdForDocument(fieldId, 0, orgId, updateBody)
         ).rejects.toThrow()
       })
     })
@@ -137,7 +119,7 @@ describe('BusinessField', () => {
     describe('when the target field does not belong to the organization', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessField.updateByIdForProjectDocument(fieldId, projectId, docId, 0, updateBody)
+          BusinessField.updateByIdForDocument(fieldId, docId, 0, updateBody)
         ).rejects.toThrow()
       })
     })
@@ -145,9 +127,8 @@ describe('BusinessField', () => {
     describe('when the passed in docId does not match the body docId', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessField.updateByIdForProjectDocument(fieldId, projectId, docId, orgId, {
+          BusinessField.updateByIdForDocument(fieldId, docId, orgId, {
             ...updateBody,
-            projectId,
             docId: 0
           })
         ).rejects.toThrow()
@@ -216,23 +197,7 @@ describe('BusinessField', () => {
           targetFieldId = factoryFields[0].id
           field = await BusinessField.findByIdForDocument(
             targetFieldId,
-            factoryProject.id,
             constants.ORG_ID_2
-          )
-        })
-
-        it('should return null', () => {
-          expect(field).toBe(null)
-        })
-      })
-
-      describe('when the target field does not have the passed in projectId', () => {
-        beforeAll(async () => {
-          targetFieldId = factoryFields[0].id
-          field = await BusinessField.findByIdForDocument(
-            targetFieldId,
-            0,
-            constants.ORG_ID
           )
         })
 

--- a/api/src/controllers/documentFields.js
+++ b/api/src/controllers/documentFields.js
@@ -8,33 +8,30 @@ import RESOURCE_TYPES from '../constants/resourceTypes'
 import fieldTypes from '../constants/fieldTypes'
 
 const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
-  RESOURCE_TYPES.PROJECT,
-  req => req.params.projectId
+  RESOURCE_TYPES.DOCUMENT,
+  req => req.params.documentId
 )
 
-// TODO: this is currently piggybacking off of project perms
 const bodySchema = Joi.compile({
   name: Joi.string().required(),
-  docId: Joi.number().required(),
-  projectId: Joi.number().required(),
+  docId: Joi.number(),
   value: Joi.alternatives(Joi.string(), Joi.number()).required(),
-  // probably want a json parse validator on this one
+  // TODO: probably want a json parse validator on this one
   structuredValue: Joi.string(),
   type: Joi.number()
     .valid(Object.values(fieldTypes.FIELD_TYPES))
     .required()
-  // TODO order: need to decide how to handle this
+  // TODO: order: need to decide how to handle this
 })
 
 const paramSchema = Joi.compile({
-  projectId: Joi.number().required(),
   documentId: Joi.number().required(),
   id: Joi.number()
 })
 
 const projectDocumentsController = function(router) {
-  // all routes are nested at projects/:projectId/documents/:documentId
-  // and receive req.params.projectId and req.params.documentId
+  // all routes are nested at documents/:documentId
+  // and receive req.params.documentId
   router.post(
     '/',
     validateParams(paramSchema),
@@ -83,13 +80,13 @@ const getDocumentField = async function(req, res) {
 
 const addDocumentField = async function(req, res) {
   const { body } = req
-  const { projectId, documentId } = req.params
+  const { documentId } = req.params
   const { orgId } = req.requestorInfo
   // Overwrite orgId even if they passed anything in
   body.orgId = orgId
 
   try {
-    const field = await BusinessField.createForProjectDocument(projectId, documentId, body)
+    const field = await BusinessField.createForDocument(documentId, body)
     res.status(201).json(field)
   } catch (e) {
     console.error(e.stack)
@@ -98,14 +95,13 @@ const addDocumentField = async function(req, res) {
 }
 
 const updateDocumentField = async function(req, res) {
-  const { id, projectId, documentId } = req.params
+  const { id, documentId } = req.params
   const { body } = req
   const { orgId } = req.requestorInfo
 
   try {
-    const field = await BusinessField.updateByIdForProjectDocument(
+    const field = await BusinessField.updateByIdForDocument(
       id,
-      projectId,
       documentId,
       orgId,
       body

--- a/api/src/controllers/documents.js
+++ b/api/src/controllers/documents.js
@@ -1,0 +1,3 @@
+const documentsController = function(router) {}
+
+export default documentsController

--- a/api/src/controllers/documents.js
+++ b/api/src/controllers/documents.js
@@ -1,3 +1,4 @@
 const documentsController = function(router) {}
-
+// using this empty controller so that we can load the child field routes in loader.js off
+// of the base /documents route, actual document routes are in projectDocuments.js
 export default documentsController

--- a/api/src/controllers/loader.js
+++ b/api/src/controllers/loader.js
@@ -16,11 +16,12 @@ const AUTHENTICATED_CONTROLLERS = {
     fileName: 'projects',
     childRoutes: {
       '/:projectId/users': { fileName: 'projectUsers' },
-      '/:projectId/documents': {
-        fileName: 'projectDocuments',
-        childRoutes: { '/:documentId/fields': { fileName: 'documentFields' } }
-      }
+      '/:projectId/documents': { fileName: 'projectDocuments' }
     }
+  },
+  '/documents': {
+    fileName: 'documents',
+    childRoutes: { '/:documentId/fields': { fileName: 'documentFields' } }
   },
   '/users': { fileName: 'users' }
 }

--- a/api/src/controllers/projectDocuments.js
+++ b/api/src/controllers/projectDocuments.js
@@ -15,7 +15,7 @@ const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
 
 const bodySchema = Joi.compile({
   name: Joi.string().required(),
-  projectId: Joi.number().required()
+  projectId: Joi.number()
 })
 
 const paramSchema = Joi.compile({

--- a/api/src/libs/middleware/reqCrudPerms.js
+++ b/api/src/libs/middleware/reqCrudPerms.js
@@ -14,7 +14,10 @@ export default (resourceType, idFunc) => {
   const listPerm = perms((req) => {
     return {
       resourceType,
-      action: actions.LIST
+      action: actions.LIST,
+      data: {
+        id: idFunc(req)
+      }
     }
   })
 
@@ -31,7 +34,10 @@ export default (resourceType, idFunc) => {
   const createPerm = perms((req) => {
     return {
       resourceType,
-      action: actions.CREATE
+      action: actions.CREATE,
+      data: {
+        id: idFunc(req)
+      }
     }
   })
 

--- a/api/src/libs/permissions/documents.js
+++ b/api/src/libs/permissions/documents.js
@@ -1,0 +1,27 @@
+import BusinessDocument from '../../businesstime/document'
+import ACTIONS from '../../constants/actions'
+
+const documentAccess = async (requestorInfo, requestedAction) => {
+  switch (requestedAction.action) {
+    case ACTIONS.READ:
+    case ACTIONS.UPDATE:
+    case ACTIONS.DELETE:
+    case ACTIONS.LIST:
+    case ACTIONS.CREATE:
+      // find the parent project for the provided document id and check perms off of that
+      // TODO: since this logic is mostly repetition from the projects permission file,
+      // we should break the check out into it's own reusable thing
+      const project = await BusinessDocument.findParentProjectByDocumentId(
+        requestedAction.data.id,
+        requestorInfo.orgId
+      )
+      console.log(project)
+
+      const hasProjectAccess = project && project.orgId === requestorInfo.orgId
+      return Boolean(hasProjectAccess)
+    default:
+      return false
+  }
+}
+
+export default documentAccess

--- a/api/src/libs/permissions/permissions.js
+++ b/api/src/libs/permissions/permissions.js
@@ -1,4 +1,5 @@
 import projectAccess from './projects'
+import documentAccess from './documents'
 import userAccess from './users'
 import RESOURCE_TYPES from '../../constants/resourceTypes'
 /*
@@ -18,6 +19,7 @@ import RESOURCE_TYPES from '../../constants/resourceTypes'
 */
 
 const resourceToHandler = {
+  [RESOURCE_TYPES.DOCUMENT]: documentAccess,
   [RESOURCE_TYPES.PROJECT]: projectAccess,
   [RESOURCE_TYPES.USER]: userAccess
 }


### PR DESCRIPTION
- remove projects/:projectId requirement for field endpoints
- build out perms to check project ownership for a document(need to DRY up these checks with the project perm file when we do the actual perm flow for those)