### PR TITLE
update api docs for new field routes

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1,4 +1,4 @@
-openapi: "3.0.2"
+openapi: '3.0.2'
 info:
   version: 1.0.0
   title: Project Danger API
@@ -84,7 +84,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of project to fetch
+          description: ID of project to update
           required: true
           schema:
             type: integer
@@ -109,7 +109,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    
+
     delete:
       description: deletes a single project based on the ID supplied
       operationId: deleteProject
@@ -130,7 +130,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
   /projects/{projectId}/documents:
     get:
       description: |
@@ -190,7 +190,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /projects/{id}/documents/{id}:
+  /projects/{projectId}/documents/{id}:
     get:
       description: Returns a document based on a single ID
       operationId: findDocumentById
@@ -199,7 +199,7 @@ paths:
           in: path
           description: ID of parent project
           required: true
-          schema: 
+          schema:
             type: integer
         - name: id
           in: path
@@ -229,11 +229,11 @@ paths:
           in: path
           description: ID of parent project
           required: true
-          schema: 
+          schema:
             type: integer
         - name: id
           in: path
-          description: ID of project to fetch
+          description: ID of project to update
           required: true
           schema:
             type: integer
@@ -266,7 +266,7 @@ paths:
           in: path
           description: ID of parent project
           required: true
-          schema: 
+          schema:
             type: integer
         - name: id
           in: path
@@ -284,20 +284,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
-  /projects/{projectId}/documents/{documentId}/fields:
+
+  /documents/{documentId}/fields:
     get:
       description: |
         Returns all fields that the user has access to for the given project/document ids
       operationId: findDocuments
       parameters:
-        - name: projectId
-          in: path
-          description: ID of parent project
-          required: true
-          schema:
-            type: integer
-
         - name: documentId
           in: path
           description: ID of parent document
@@ -324,13 +317,6 @@ paths:
       description: Creates a new field
       operationId: addField
       parameters:
-        - name: projectId
-          in: path
-          description: ID of parent project
-          required: true
-          schema:
-            type: integer
-
         - name: documentId
           in: path
           description: ID of parent document
@@ -358,22 +344,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /projects/{projectId}/documents/{documentId}/fields/{id}:
+  /documents/{documentId}/fields/{id}:
     get:
       description: Returns a field based on a single ID
       operationId: findFieldById
       parameters:
-        - name: projectId
-          in: path
-          description: ID of parent project
-          required: true
-          schema: 
-            type: integer
         - name: documentId
           in: path
           description: ID of parent document
           required: true
-          schema: 
+          schema:
             type: integer
         - name: id
           in: path
@@ -399,21 +379,15 @@ paths:
       description: Update a field based on a single ID - full or partial update
       operationId: updateField
       parameters:
-        - name: projectId
-          in: path
-          description: ID of parent project
-          required: true
-          schema: 
-            type: integer
         - name: documentId
           in: path
           description: ID of parent document
           required: true
-          schema: 
+          schema:
             type: integer
         - name: id
           in: path
-          description: ID of field to fetch
+          description: ID of field to update
           required: true
           schema:
             type: integer
@@ -438,26 +412,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    
+
     delete:
       description: deletes a single field based on the ID supplied
       operationId: deleteField
       parameters:
-        - name: projectId
-          in: path
-          description: ID of parent project
-          required: true
-          schema: 
-            type: integer
         - name: documentId
           in: path
           description: ID of parent document
           required: true
-          schema: 
+          schema:
             type: integer
         - name: id
           in: path
-          description: ID of field to fetch
+          description: ID of field to delete
           required: true
           schema:
             type: integer
@@ -471,18 +439,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
 components:
   schemas:
     Project:
       allOf:
         - $ref: '#/components/schemas/NewProject'
         - required:
-          - id
+            - id
           properties:
             id:
               type: integer
-  
             createdAt:
               type: string
               format: date-time
@@ -496,18 +463,17 @@ components:
       properties:
         name:
           type: string
-        documentId:
-          type: integer
 
     Document:
       allOf:
         - $ref: '#/components/schemas/NewDocument'
         - required:
-          - id
+            - id
           properties:
             id:
               type: integer
-  
+            projectId:
+              type: integer
             createdAt:
               type: string
               format: date-time
@@ -521,17 +487,21 @@ components:
       properties:
         name:
           type: string
-        projectId:
-          type: integer
 
     Field:
       allOf:
-        - $ref: '#/components/schemas/NewDocument'
+        - $ref: '#/components/schemas/NewField'
         - required:
-          - id
+            - id
           properties:
             id:
               type: integer
+            docId:
+              type: integer
+            type:
+              type: integer
+            value:
+              type: string
             createdAt:
               type: string
               format: date-time
@@ -540,31 +510,64 @@ components:
               format: date-time
 
     NewField:
+      oneOf:
+        - $ref: '#/components/schemas/StringField'
+        - $ref: '#/components/schemas/TextField'
+        - $ref: '#/components/schemas/NumberField'
+
+    StringField:
       required:
-        - name
+          - name
+          - type
+          - value
       properties:
         name:
           type: string
-        projectId:
+        type:
           type: integer
-        docId:  
-          type: integer
+          enum: [1]
         value:
-          oneOf:
-            - type: string
-            - type: integer
-        structuredValue:
+          type: string
+
+    TextField:
+      required:
+        - name
+        - type
+        - value
+      properties:
+        name:
           type: string
         type:
           type: integer
+          enum: [2]
+        value:
+          type: string
+        structuredValue:
+          type: string
 
+    NumberField:
+      required:
+          - name
+          - type
+          - value
+      properties:
+        name:
+          type: string
+        type:
+          type: integer
+          enum: [3]
+        value:
+          type: integer
 
     Error:
       required:
         - code
         - message
       properties:
-        code:
-          type: integer
-        message:
-          type: string
+        error:
+          type: object
+          properties:
+            code:
+              type: integer
+            message:
+              type: string


### PR DESCRIPTION
updates some API documentation

seems like the vscode viewer we're using doesn't fully support oneOf correctly which is a newish thing in the OpenApi spec, so some field-props are currently double defined