### PR TITLE
Web – Delete documents

### DIFF
--- a/web/.babelrc
+++ b/web/.babelrc
@@ -1,4 +1,14 @@
 {
   "plugins": ["@babel/plugin-syntax-dynamic-import"],
-  "presets": [["@babel/preset-env", { "targets": { "node": "current"}}], "@babel/preset-react"]
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "edge": "17",
+        "firefox": "60",
+        "chrome": "67",
+        "safari": "11.1",
+      }
+    }],
+    "@babel/preset-react"
+  ]
 }

--- a/web/src/client/css/inc/_buttons.scss
+++ b/web/src/client/css/inc/_buttons.scss
@@ -29,8 +29,6 @@ button,
   margin-top: 0;
   padding: 10px 37px;
   text-decoration: none;
-  transition: transform 0.2s ease-in-out;
-  will-change: transform;
   -webkit-appearance: none;
 
   @include focus($action);
@@ -41,7 +39,6 @@ button,
   &:active {
     background-color: $action-dark;
     color: #fff;
-    transform: translateY(0);
   }
 
   &--white {

--- a/web/src/client/css/inc/_buttons.scss
+++ b/web/src/client/css/inc/_buttons.scss
@@ -93,9 +93,9 @@ button,
     .icon {
       background-color: $white-bis;
       border-radius: 50% 50%;
-      margin-right: 8px;
     }
     .label {
+      margin-left: 8px;
       padding: 0 12px 0 0;
     }
     &:hover {

--- a/web/src/client/css/inc/_react-select.scss
+++ b/web/src/client/css/inc/_react-select.scss
@@ -30,7 +30,6 @@
           margin: 0;
           position: relative;
           transition: none;
-          will-change: unset;
           // Override default .menu stuff
           &:not([hidden]) {
             box-shadow: none;

--- a/web/src/client/css/layout/_menu.scss
+++ b/web/src/client/css/layout/_menu.scss
@@ -55,7 +55,7 @@ $menuBorderRadius: 8px;
   cursor: pointer;
   display: block;
   text-decoration: none;
-  min-width: 100px;
+  min-width: 210px;
   padding: 8px 14px;
   width: 100%;
   &:hover {
@@ -91,6 +91,12 @@ $menuBorderRadius: 8px;
   a, button {
     @extend .menu__item;
     text-align: left;
+    &.btn--warning {
+      color: $warning;
+    }
+    &.btn--danger {
+      color: $danger;
+    }
   }
 }
 

--- a/web/src/client/css/layout/_menu.scss
+++ b/web/src/client/css/layout/_menu.scss
@@ -10,7 +10,6 @@ $menuBorderRadius: 8px;
   overflow: hidden;
   padding: 0;
   position: absolute;
-  will-change: visibility, transform, opacity;
   z-index: 10;
   // remove any list padding / margin and style
   > ol,

--- a/web/src/client/images/icon/menu-more.svg
+++ b/web/src/client/images/icon/menu-more.svg
@@ -1,9 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
-    <title>icon/menu-more</title>
-    <desc>Created with Sketch.</desc>
-    <g id="icon/menu-more" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <path d="M18,21 C16.3431458,21 15,19.6568542 15,18 C15,16.3431458 16.3431458,15 18,15 C19.6568542,15 21,16.3431458 21,18 C21,19.6568542 19.6568542,21 18,21 Z M28,21 C26.3431458,21 25,19.6568542 25,18 C25,16.3431458 26.3431458,15 28,15 C29.6568542,15 31,16.3431458 31,18 C31,19.6568542 29.6568542,21 28,21 Z M8,21 C6.34314575,21 5,19.6568542 5,18 C5,16.3431458 6.34314575,15 8,15 C9.65685425,15 11,16.3431458 11,18 C11,19.6568542 9.65685425,21 8,21 Z" id="Combined-Shape" fill="#3B3D3E"></path>
-    </g>
-</svg>
+<svg height="36" viewBox="0 0 36 36" width="36" xmlns="http://www.w3.org/2000/svg"><path d="m18 21c-1.6568542 0-3-1.3431458-3-3s1.3431458-3 3-3 3 1.3431458 3 3-1.3431458 3-3 3zm10 0c-1.6568542 0-3-1.3431458-3-3s1.3431458-3 3-3 3 1.3431458 3 3-1.3431458 3-3 3zm-20 0c-1.65685425 0-3-1.3431458-3-3s1.34314575-3 3-3 3 1.3431458 3 3-1.34314575 3-3 3z" fill="#3b3d3e" fill-rule="evenodd"/></svg>

--- a/web/src/client/js/actions/document.js
+++ b/web/src/client/js/actions/document.js
@@ -35,7 +35,7 @@ export const updateDocument = (projectId, documentId, body) => {
   }
 }
 
-export const deleteDocument = (projectId, documentId) => {
+export const deleteDocument = (projectId, documentId, history) => {
   return async (dispatch) => {
     dispatch(Documents.delete(projectId, documentId))
     const data = await remove(`projects/${projectId}/documents/${documentId}`, {
@@ -43,5 +43,6 @@ export const deleteDocument = (projectId, documentId) => {
       id: documentId
     })
     dispatch(Documents.deleted(projectId, documentId, data))
+    history.push({ pathname: `${Constants.PATH_PROJECT}/${projectId}` })
   }
 }

--- a/web/src/client/js/actions/document.js
+++ b/web/src/client/js/actions/document.js
@@ -30,7 +30,7 @@ export const createDocument = (projectId, history, body) => {
 export const updateDocument = (projectId, documentId, body) => {
   return async (dispatch) => {
     dispatch(Documents.update(projectId, documentId, body))
-    const data = await update(`projects/${projectId}/documents/${documentId}`, body)
+    const { data } = await update(`projects/${projectId}/documents/${documentId}`, body)
     dispatch(Documents.receiveOneUpdated(data))
   }
 }

--- a/web/src/client/js/actions/document.js
+++ b/web/src/client/js/actions/document.js
@@ -1,6 +1,6 @@
 import Constants from 'Shared/constants'
 import { Documents } from './index'
-import { add, fetch, update } from '../api'
+import { add, fetch, update, remove } from '../api'
 
 export const fetchDocuments = (projectId) => {
   return async (dispatch) => {
@@ -27,10 +27,21 @@ export const createDocument = (projectId, history, body) => {
   }
 }
 
-export const updateDocument = (documentId, projectId, body) => {
+export const updateDocument = (projectId, documentId, body) => {
   return async (dispatch) => {
-    dispatch(Documents.update(documentId))
+    dispatch(Documents.update(projectId, documentId, body))
     const data = await update(`projects/${projectId}/documents/${documentId}`, body)
     dispatch(Documents.receiveOneUpdated(data))
+  }
+}
+
+export const deleteDocument = (projectId, documentId) => {
+  return async (dispatch) => {
+    dispatch(Documents.delete(projectId, documentId))
+    const data = await remove(`projects/${projectId}/documents/${documentId}`, {
+      projectId: projectId,
+      id: documentId
+    })
+    dispatch(Documents.deleted(projectId, documentId, data))
   }
 }

--- a/web/src/client/js/actions/index.js
+++ b/web/src/client/js/actions/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { makeActionCreator } from '../utilities/redux'
 
 export const ActionTypes = {
@@ -15,10 +16,12 @@ export const ActionTypes = {
   // Documents
   REQUEST_DOCUMENTS: 'REQUEST_DOCUMENTS',
   RECEIVE_DOCUMENTS: 'RECEIVE_DOCUMENTS',
-  CREATE_DOCUMENT: 'CREATE_DOCUMENT',
-  UPDATE_DOCUMENT: 'UPDATE_DOCUMENT',
+  INITIATE_CREATE_DOCUMENT: 'INITIATE_CREATE_DOCUMENT',
   RECEIVE_CREATED_DOCUMENT: 'RECEIVE_CREATED_DOCUMENT',
+  INITIATE_UPDATE_DOCUMENT: 'INITIATE_UPDATE_DOCUMENT',
   RECEIVE_UPDATED_DOCUMENT: 'RECEIVE_UPDATED_DOCUMENT',
+  INITIATE_DOCUMENT_REMOVE: 'INITIATE_DOCUMENT_REMOVE',
+  DOCUMENT_REMOVED: 'DOCUMENT_REMOVED',
   REQUEST_DOCUMENT: 'REQUEST_DOCUMENT',
   RECEIVE_DOCUMENT: 'RECEIVE_DOCUMENT',
   // Fields
@@ -51,10 +54,12 @@ export const Projects = {
 }
 
 export const Documents = {
-  create: makeActionCreator(ActionTypes.CREATE_DOCUMENT, 'projectId', 'data'),
-  update: makeActionCreator(ActionTypes.UPDATE_DOCUMENT, 'projectId', 'documentId', 'data'),
+  create: makeActionCreator(ActionTypes.INITIATE_CREATE_DOCUMENT, 'projectId', 'data'),
   receiveOneCreated: makeActionCreator(ActionTypes.RECEIVE_CREATED_DOCUMENT, 'data'),
+  update: makeActionCreator(ActionTypes.INITIATE_UPDATE_DOCUMENT, 'projectId', 'documentId', 'data'),
   receiveOneUpdated: makeActionCreator(ActionTypes.RECEIVE_UPDATED_DOCUMENT, 'data'),
+  delete: makeActionCreator(ActionTypes.INITIATE_DOCUMENT_REMOVE, 'projectId', 'documentId'),
+  deleted: makeActionCreator(ActionTypes.DOCUMENT_REMOVED, 'projectId', 'documentId'),
   requestOne: makeActionCreator(ActionTypes.REQUEST_DOCUMENT, 'projectId', 'documentId'),
   receiveOne: makeActionCreator(ActionTypes.RECEIVE_DOCUMENT, 'data'),
   requestList: makeActionCreator(ActionTypes.REQUEST_DOCUMENTS, 'projectId'),

--- a/web/src/client/js/actions/index.js
+++ b/web/src/client/js/actions/index.js
@@ -16,12 +16,12 @@ export const ActionTypes = {
   // Documents
   REQUEST_DOCUMENTS: 'REQUEST_DOCUMENTS',
   RECEIVE_DOCUMENTS: 'RECEIVE_DOCUMENTS',
-  INITIATE_CREATE_DOCUMENT: 'INITIATE_CREATE_DOCUMENT',
+  INITIATE_DOCUMENT_CREATE: 'INITIATE_DOCUMENT_CREATE',
   RECEIVE_CREATED_DOCUMENT: 'RECEIVE_CREATED_DOCUMENT',
-  INITIATE_UPDATE_DOCUMENT: 'INITIATE_UPDATE_DOCUMENT',
+  INITIATE_DOCUMENT_UPDATE: 'INITIATE_UPDATE_DOCUMENT',
   RECEIVE_UPDATED_DOCUMENT: 'RECEIVE_UPDATED_DOCUMENT',
   INITIATE_DOCUMENT_REMOVE: 'INITIATE_DOCUMENT_REMOVE',
-  DOCUMENT_REMOVED: 'DOCUMENT_REMOVED',
+  REMOVE_DOCUMENT: 'REMOVE_DOCUMENT',
   REQUEST_DOCUMENT: 'REQUEST_DOCUMENT',
   RECEIVE_DOCUMENT: 'RECEIVE_DOCUMENT',
   // Fields
@@ -54,12 +54,12 @@ export const Projects = {
 }
 
 export const Documents = {
-  create: makeActionCreator(ActionTypes.INITIATE_CREATE_DOCUMENT, 'projectId', 'data'),
+  create: makeActionCreator(ActionTypes.INITIATE_DOCUMENT_CREATE, 'projectId', 'data'),
   receiveOneCreated: makeActionCreator(ActionTypes.RECEIVE_CREATED_DOCUMENT, 'data'),
-  update: makeActionCreator(ActionTypes.INITIATE_UPDATE_DOCUMENT, 'projectId', 'documentId', 'data'),
+  update: makeActionCreator(ActionTypes.INITIATE_DOCUMENT_UPDATE, 'projectId', 'documentId', 'data'),
   receiveOneUpdated: makeActionCreator(ActionTypes.RECEIVE_UPDATED_DOCUMENT, 'data'),
   delete: makeActionCreator(ActionTypes.INITIATE_DOCUMENT_REMOVE, 'projectId', 'documentId'),
-  deleted: makeActionCreator(ActionTypes.DOCUMENT_REMOVED, 'projectId', 'documentId'),
+  deleted: makeActionCreator(ActionTypes.REMOVE_DOCUMENT, 'projectId', 'documentId'),
   requestOne: makeActionCreator(ActionTypes.REQUEST_DOCUMENT, 'projectId', 'documentId'),
   receiveOne: makeActionCreator(ActionTypes.RECEIVE_DOCUMENT, 'data'),
   requestList: makeActionCreator(ActionTypes.REQUEST_DOCUMENTS, 'projectId'),

--- a/web/src/client/js/components/Document/Document.scss
+++ b/web/src/client/js/components/Document/Document.scss
@@ -3,6 +3,12 @@
 
 .document {
 
+  header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
   &__title {
     border: none;
     color: $primary;
@@ -11,7 +17,6 @@
     font-weight: 700;
     line-height: 1em;
     outline: none;
-    padding-bottom: $sideGutterWidth / 2;
     resize: none;
     width: 100%;
     -webkit-appearance: none;

--- a/web/src/client/js/components/Document/Document.scss
+++ b/web/src/client/js/components/Document/Document.scss
@@ -4,7 +4,7 @@
 .document {
 
   header {
-    align-items: center;
+    align-items: flex-start;
     display: flex;
     justify-content: space-between;
   }
@@ -16,6 +16,7 @@
     font-size: 1.2rem;
     font-weight: 700;
     line-height: 1em;
+    padding-top: 8px;
     outline: none;
     resize: none;
     width: 100%;

--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -1,26 +1,54 @@
 import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 
-import { AddIcon } from 'Components/Icons'
+import { debounce } from 'Shared/utilities'
+import { AddIcon, MoreIcon } from 'Components/Icons'
+import DropdownComponent from 'Components/Dropdown/DropdownComponent'
 
 import './Document.scss'
 
-const DocumentComponent = ({ document, nameChangeHandler }) => {
+const DocumentComponent = ({ document, nameChangeHandler, removeDocumentHandler }) => {
   const titleRef = useRef()
   const docKey = document ? document.id : 0
+  const dropdownButton = {
+    className: 'btn btn--blank btn--with-circular-icon',
+    icon: <MoreIcon width="18" height="18" />
+  }
+  const changeHandlerAction = debounce(500, (e) => {
+    nameChangeHandler(e)
+  })
   return (
     <div className="document" key={docKey}>
       <header>
-        <textarea
+        <div
+          contentEditable
           className="document__title"
+          onInput={(e) => {
+            e.persist()
+            changeHandlerAction(e)
+          }}
           onKeyDown={(e) => {
             if (e.key.toLowerCase() === 'enter') {
               nameChangeHandler(e)
               titleRef.current.blur()
             }
           }}
-          defaultValue={document.name}
-          ref={titleRef} />
+          ref={titleRef}
+          role="textbox"
+          suppressContentEditableWarning
+          tabIndex={0}>
+          {document.name}
+        </div>
+        <DropdownComponent
+          align="right"
+          button={dropdownButton}
+          className="document__document-dropdown">
+          <li>
+            <button className="menu__item btn--danger" onClick={removeDocumentHandler}>
+              Delete document...
+            </button>
+          </li>
+        </DropdownComponent>
       </header>
       {document &&
       <button className="field-button" aria-label="Add a field" title="Add a field">
@@ -37,7 +65,8 @@ const DocumentComponent = ({ document, nameChangeHandler }) => {
 // @todo fill out this document object and add defaults
 DocumentComponent.propTypes = {
   document: PropTypes.object,
-  nameChangeHandler: PropTypes.func.isRequired
+  nameChangeHandler: PropTypes.func.isRequired,
+  removeDocumentHandler: PropTypes.func.isRequired
 }
 
 export default DocumentComponent

--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -20,10 +20,10 @@ const DocumentComponent = ({ document, nameChangeHandler, removeDocumentHandler 
   return (
     <div className="document" key={docKey}>
       <header>
-        <div
-          contentEditable
+        <textarea
           className="document__title"
-          onInput={(e) => {
+          defaultValue={document.name}
+          onChange={(e) => {
             e.persist()
             changeHandlerAction(e)
           }}
@@ -33,12 +33,7 @@ const DocumentComponent = ({ document, nameChangeHandler, removeDocumentHandler 
               titleRef.current.blur()
             }
           }}
-          ref={titleRef}
-          role="textbox"
-          suppressContentEditableWarning
-          tabIndex={0}>
-          {document.name}
-        </div>
+          ref={titleRef} />
         <DropdownComponent
           align="right"
           button={dropdownButton}

--- a/web/src/client/js/components/Document/DocumentContainer.js
+++ b/web/src/client/js/components/Document/DocumentContainer.js
@@ -33,9 +33,9 @@ const DocumentContainer = ({ deleteDocument, history, location, ui, updateDocume
    * Otherwise we render the document, and update its values onChange
    */
   function nameChangeHandler(e) {
-    if (e.target.textContent !== document.name) {
+    if (e.target.value !== document.name) {
       updateDocument(document.projectId, document.id, {
-        name: e.target.textContent,
+        name: e.target.value,
         projectId: document.projectId
       })
     }

--- a/web/src/client/js/components/Document/DocumentContainer.js
+++ b/web/src/client/js/components/Document/DocumentContainer.js
@@ -9,7 +9,7 @@ import currentResource from 'Libs/currentResource'
 
 import DocumentComponent from './DocumentComponent'
 
-const DocumentContainer = ({ deleteDocument, location, ui, updateDocument }) => {
+const DocumentContainer = ({ deleteDocument, history, location, ui, updateDocument }) => {
   const { data: document } = useDataService(currentResource('document', location.pathname), [
     location.pathname
   ])
@@ -33,7 +33,6 @@ const DocumentContainer = ({ deleteDocument, location, ui, updateDocument }) => 
    * Otherwise we render the document, and update its values onChange
    */
   function nameChangeHandler(e) {
-    console.log(document)
     if (e.target.textContent !== document.name) {
       updateDocument(document.projectId, document.id, {
         name: e.target.textContent,
@@ -42,7 +41,7 @@ const DocumentContainer = ({ deleteDocument, location, ui, updateDocument }) => 
     }
   }
   function removeDocumentHandler() {
-    deleteDocument(document.projectId, document.id)
+    deleteDocument(document.projectId, document.id, history)
   }
   return <DocumentComponent
     nameChangeHandler={nameChangeHandler}
@@ -52,6 +51,7 @@ const DocumentContainer = ({ deleteDocument, location, ui, updateDocument }) => 
 
 DocumentContainer.propTypes = {
   deleteDocument: PropTypes.func.isRequired,
+  history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
   ui: PropTypes.object.isRequired,
   updateDocument: PropTypes.func.isRequired

--- a/web/src/client/js/components/Document/DocumentContainer.js
+++ b/web/src/client/js/components/Document/DocumentContainer.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
 
-import { updateDocument } from 'Actions/document'
+import { updateDocument, deleteDocument } from 'Actions/document'
 import useDataService from 'Hooks/useDataService'
 import currentResource from 'Libs/currentResource'
 
-import { debounce } from 'Shared/utilities'
 import DocumentComponent from './DocumentComponent'
 
-const DocumentContainer = ({ location, ui, updateDocument }) => {
+const DocumentContainer = ({ deleteDocument, location, ui, updateDocument }) => {
   const { data: document } = useDataService(currentResource('document', location.pathname), [
     location.pathname
   ])
@@ -31,26 +30,28 @@ const DocumentContainer = ({ location, ui, updateDocument }) => {
   }
 
   /**
-   * Otherwise we rendre the document, and update its values onChange
+   * Otherwise we render the document, and update its values onChange
    */
-  const nameChangeAction = debounce(1000, (e) => {
-    if (e.target.value !== document.name) {
-      updateDocument(document.id, document.projectId, {
-        name: e.target.value,
+  function nameChangeHandler(e) {
+    console.log(document)
+    if (e.target.textContent !== document.name) {
+      updateDocument(document.projectId, document.id, {
+        name: e.target.textContent,
         projectId: document.projectId
       })
     }
-  })
-  function nameChangeHandler(e) {
-    e.persist()
-    nameChangeAction(e)
+  }
+  function removeDocumentHandler() {
+    deleteDocument(document.projectId, document.id)
   }
   return <DocumentComponent
     nameChangeHandler={nameChangeHandler}
+    removeDocumentHandler={removeDocumentHandler}
     document={document} />
 }
 
 DocumentContainer.propTypes = {
+  deleteDocument: PropTypes.func.isRequired,
   location: PropTypes.object.isRequired,
   ui: PropTypes.object.isRequired,
   updateDocument: PropTypes.func.isRequired
@@ -63,6 +64,7 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = {
+  deleteDocument,
   updateDocument
 }
 

--- a/web/src/client/js/components/DocumentsList/DocumentsList.scss
+++ b/web/src/client/js/components/DocumentsList/DocumentsList.scss
@@ -12,6 +12,31 @@
     transition: opacity 0.2s ease-in-out;
     // New item is a fake list item
     &--new {
+      .documents-list__button {
+        align-items: flex-start;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding-bottom: 10px;
+        .btn--with-circular-icon {
+          padding: 0;
+          .icon {
+            background-color: $white-ter;
+            height: 30px;
+            margin-right: 0;
+            width: 30px;
+          }
+        }
+      }
+      .documents-list__name {
+        background-color: transparent;
+        flex: 1;
+        line-height: 1em;
+        outline: none;
+        padding-bottom: 0;
+        padding-top: 8px;
+        resize: none;
+      }
       &:focus {
         background-color: $white-bis;
       }
@@ -27,22 +52,6 @@
         background-color: $white-bis;
       }
     }
-    .documents-list__item--new & {
-      align-items: center;
-      display: flex;
-      flex-direction: row;
-      height: 85.5px;
-      justify-content: space-between;
-      .btn--with-circular-icon {
-        padding: 0;
-        .icon {
-          background-color: $white-ter;
-          height: 30px;
-          margin-right: 0;
-          width: 30px;
-        }
-      }
-    }
   }
   &__name {
     border: 0;
@@ -50,14 +59,6 @@
     padding-bottom: $sideGutterWidth / 4;
     .active & {
       color: $black-bis;
-    }
-    // the textarea we're typing in
-    .documents-list__item--new & {
-      flex: 1;
-      line-height: 1em;
-      outline: none;
-      padding: 24px 0;
-      resize: none;
     }
   }
   &__date {

--- a/web/src/client/js/components/DocumentsList/DocumentsListComponent.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListComponent.js
@@ -5,7 +5,6 @@ import cx from 'classnames'
 import { AddIcon, RemoveIcon } from 'Components/Icons'
 import ToolbarComponent from 'Components/Toolbar/ToolbarComponent'
 import DocumentsListItem from './DocumentsListItem'
-
 import './DocumentsList.scss'
 
 const DocumentsListComponent = ({ createChangeHandler, creating, createCallback, documents }) => {
@@ -14,11 +13,7 @@ const DocumentsListComponent = ({ createChangeHandler, creating, createCallback,
   // Select the contents of the contentEditable div (new document name)
   useEffect(() => {
     if (creating && nameRef.current) {
-      const range = document.createRange()
-      range.selectNodeContents(nameRef.current)
-      const sel = document.getSelection()
-      sel.removeAllRanges()
-      sel.addRange(range)
+      nameRef.current.select()
     }
   })
 
@@ -36,18 +31,16 @@ const DocumentsListComponent = ({ createChangeHandler, creating, createCallback,
       return (
         <li className="documents-list__item documents-list__item--new">
           <div className="documents-list__button">
-            <div contentEditable
+            <textarea
               ref={nameRef}
-              role="textbox"
-              tabIndex={0}
               className="documents-list__name"
-              suppressContentEditableWarning
+              defaultValue="New Document"
               onKeyDown={(e) => {
                 if (e.key.toLowerCase() === 'enter') {
                   e.preventDefault()
                   createChangeHandler(e)
                 }
-              }}>New Document</div>
+              }} />
             <button
               className="btn btn--blank btn--with-circular-icon"
               onClick={() => { createCallback(false) }}>

--- a/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
@@ -17,7 +17,7 @@ const DocumentsListContainer = ({ createDocument, uiDocumentCreate, history, ui,
 
   const createDocumentAction = (e) => {
     createDocument(match.params.projectId, history, {
-      name: e.target.textContent,
+      name: e.target.value,
       projectId: match.params.projectId
     })
   }

--- a/web/src/client/js/components/Header/Header.js
+++ b/web/src/client/js/components/Header/Header.js
@@ -30,7 +30,7 @@ const renderProjectsItems = () => {
         title="Create a new project"
         to={Constants.PATH_PROJECT_CREATE}>
         <AddIcon width="12" height="12" />
-        New Project
+        <span className="label">New Project</span>
       </Link>
     </div>
   )

--- a/web/src/client/js/components/Icons/MoreIcon.js
+++ b/web/src/client/js/components/Icons/MoreIcon.js
@@ -1,0 +1,30 @@
+/* eslint-disable max-len */
+import React from 'react'
+import PropTypes from 'prop-types'
+
+function MoreIcon({ className, fill, height, width }) {
+  // xmlns="http://www.w3.org/2000/svg"
+  return (
+    <div className="icon">
+      <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width={width} height={height}>
+        <path fill={fill} fillRule="evenodd" d="m18 21c-1.6568542 0-3-1.3431458-3-3s1.3431458-3 3-3 3 1.3431458 3 3-1.3431458 3-3 3zm10 0c-1.6568542 0-3-1.3431458-3-3s1.3431458-3 3-3 3 1.3431458 3 3-1.3431458 3-3 3zm-20 0c-1.65685425 0-3-1.3431458-3-3s1.34314575-3 3-3 3 1.3431458 3 3-1.34314575 3-3 3z" />
+      </svg>
+    </div>
+  )
+}
+
+MoreIcon.propTypes = {
+  className: PropTypes.string,
+  fill: PropTypes.string,
+  height: PropTypes.string,
+  width: PropTypes.string
+}
+
+MoreIcon.defaultProps = {
+  className: 'icon-more',
+  fill: '#3b3d3e',
+  height: '36',
+  width: '36'
+}
+
+export default MoreIcon

--- a/web/src/client/js/components/Icons/index.js
+++ b/web/src/client/js/components/Icons/index.js
@@ -1,6 +1,7 @@
 export { default as AddIcon } from './AddIcon'
 export { default as CaretIcon } from './CaretIcon'
 export { default as FilterIcon } from './FilterIcon'
+export { default as MoreIcon } from './MoreIcon'
 export { default as ProjectIcon } from './ProjectIcon'
 export { default as RemoveIcon } from './RemoveIcon'
 export { default as SortIcon } from './SortIcon'

--- a/web/src/client/js/components/Navigator/NavigatorContainer.js
+++ b/web/src/client/js/components/Navigator/NavigatorContainer.js
@@ -73,7 +73,7 @@ const NavigatorContainer = ({ history, location }) => {
         className="btn btn--blank btn--with-circular-icon"
         onClick={toggleCallback}>
         <CaretIcon width="12" height="12" />
-        {project ? project.name : 'Projects'}
+        <span className="label">{project ? project.name : 'Projects'}</span>
       </button>
       <div className="menu menu--dark" hidden={!expanded}>
         <Select

--- a/web/src/client/js/components/ProjectsList/ProjectList.scss
+++ b/web/src/client/js/components/ProjectsList/ProjectList.scss
@@ -22,7 +22,6 @@ $horizontalPadding: 1.3%;
       transform: translateX(-50%);
       &--animate {
         transition: width 0.3s ease-in-out, height 0.2s ease-in-out, margin 0.2s ease-in-out, opacity 0.4s ease-in-out;
-        // will-change: auto;
       }
       &--disabled {
         opacity: .2;
@@ -55,7 +54,6 @@ $horizontalPadding: 1.3%;
       display: flex;
       flex: 1;
       padding: 12px $horizontalPadding 12px 0;
-      // will-change: contents;
       transition: padding 0.3s ease-in-out;
       .icon {
         margin-right: $horizontalPadding;

--- a/web/src/client/js/components/Toolbar/ToolbarComponent.js
+++ b/web/src/client/js/components/Toolbar/ToolbarComponent.js
@@ -22,7 +22,7 @@ const ToolbarComponent = ({ action, filter, sort }) => {
           onClick={action.callback}
           title={action.title}>
           {action.icon}
-          {action.label}
+          {action.label && <span className="label">{action.label}</span>}
         </button>
       </div>
       <div className="toolbar__end">

--- a/web/src/client/js/libs/dataMapper.js
+++ b/web/src/client/js/libs/dataMapper.js
@@ -27,10 +27,10 @@ export default {
       return {
         fetchAction: fetchDocuments(projectId),
         getLoadingStatusFromState: (state) => {
-          return state.documents.loading.list[projectId]
+          return state.documents.loading.byProject[projectId]
         },
         getDataFromState: (state) => {
-          return state.documents.list[projectId]
+          return state.documents.projectDocumentsById[projectId]
         }
       }
     },
@@ -41,7 +41,7 @@ export default {
           return state.documents.loading.byId[documentId]
         },
         getDataFromState: (state) => {
-          return state.documents.documentsById[documentId]
+          return state.documents.projectDocumentsById[projectId][documentId]
         }
       }
     }

--- a/web/src/client/js/libs/dataMapper.js
+++ b/web/src/client/js/libs/dataMapper.js
@@ -41,7 +41,8 @@ export default {
           return state.documents.loading.byId[documentId]
         },
         getDataFromState: (state) => {
-          return state.documents.projectDocumentsById[projectId][documentId]
+          return state.documents.projectDocumentsById[projectId] &&
+            state.documents.projectDocumentsById[projectId][documentId]
         }
       }
     }

--- a/web/src/client/js/reducers/documents.js
+++ b/web/src/client/js/reducers/documents.js
@@ -1,40 +1,39 @@
+/* eslint-disable max-len */
 import { ActionTypes } from '../actions'
 
 const initialState = {
-  list: {},
-  documentsById: {},
+  projectDocumentsById: {},
   loading: {
-    list: {},
+    byProject: {},
     byId: {}
   }
 }
 
 export const documents = (state = initialState, action) => {
   switch (action.type) {
-    // Multiple documents
     case ActionTypes.REQUEST_DOCUMENTS: {
-      const list = { ...state.loading.list, [action.projectId]: true }
+      const byProject = { ...state.loading.byProject, [action.projectId]: true }
       return {
         ...state,
         loading: {
           ...state.loading,
-          list
+          byProject
         }
       }
     }
     case ActionTypes.RECEIVE_DOCUMENTS: {
-      const loadingList = { ...state.loading.list, [action.projectId]: false }
+      const loadingList = { ...state.loading.byProject, [action.projectId]: false }
       const documentsObject = action.data.reduce((object, doc) => {
         object[doc.id] = doc
         return object
       }, {})
-      const list = { ...state.list, [action.projectId]: documentsObject }
+      const projectDocumentsById = { ...state.projectDocumentsById, [action.projectId]: documentsObject }
       return {
         ...state,
-        list,
+        projectDocumentsById,
         loading: {
           ...state.loading,
-          list: loadingList
+          byProject: loadingList
         }
       }
     }
@@ -51,14 +50,12 @@ export const documents = (state = initialState, action) => {
     case ActionTypes.RECEIVE_DOCUMENT: {
       const byId = { ...state.loading.byId, [action.data.id]: false }
       const currentDocumentId = action.data.id
-      const documentsById = {
-        ...state.documentsById,
-        [action.data.id]: action.data
-      }
+      const project = { ...state.projectDocumentsById[action.data.projectId], [action.data.id]: action.data }
+      const projectDocumentsById = { ...state.projectDocumentsById, [action.data.projectId]: project }
       return {
         ...state,
         currentDocumentId,
-        documentsById,
+        projectDocumentsById,
         loading: {
           ...state.loading,
           byId
@@ -67,48 +64,78 @@ export const documents = (state = initialState, action) => {
     }
     case ActionTypes.RECEIVE_CREATED_DOCUMENT: {
       const byId = { ...state.loading.byId, [action.data.id]: false }
+      const byProject = { ...state.loading.byProject, [action.projectId]: false }
       const currentDocumentId = action.data.id
-      const documentsById = {
-        ...state.documentsById,
-        [action.data.id]: action.data
-      }
-      // Adjust the documents list
-      const project = {
-        ...state.list[action.data.projectId],
-        [action.data.id]: action.data
-      }
+      const project = { ...state.projectDocumentsById[action.data.projectId], [action.data.id]: action.data }
+      const projectDocumentsById = { ...state.projectDocumentsById, [action.data.projectId]: project }
       return {
         ...state,
         currentDocumentId,
-        documentsById,
-        list: {
-          ...state.list,
-          [action.data.projectId]: project
-        },
+        projectDocumentsById,
         loading: {
           ...state.loading,
+          byProject,
           byId
         }
       }
     }
-    case ActionTypes.RECEIVE_UPDATED_DOCUMENT:
-      const listDoc = state.list[action.data.projectId][action.data.id]
+    case ActionTypes.INITIATE_UPDATE_DOCUMENT: {
+      const byId = { ...state.loading.byId, [action.documentId]: true }
+      const byProject = { ...state.loading.byProject, [action.projectId]: true }
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          byId,
+          byProject
+        }
+      }
+    }
+    case ActionTypes.RECEIVE_UPDATED_DOCUMENT: {
+      const byId = { ...state.loading.byId, [action.data.id]: false }
+      const byProject = { ...state.loading.byProject, [action.data.projectId]: false }
+      const listDoc = state.projectDocumentsById[action.data.projectId][action.data.id]
       const updatedDoc = {
         ...listDoc,
         name: action.data.name,
         updatedAt: action.data.updatedAt
       }
-      const project = {
-        ...state.list[action.data.projectId],
-        [action.data.id]: updatedDoc
-      }
+      const project = { ...state.projectDocumentsById[action.data.projectId], [action.data.id]: updatedDoc }
+      const projectDocumentsById = { ...state.projectDocumentsById, [action.data.projectId]: project }
       return {
         ...state,
-        list: {
-          ...state.list,
-          [action.data.projectId]: project
+        projectDocumentsById,
+        loading: {
+          ...state.loading,
+          byProject,
+          byId
         }
       }
+    }
+    case ActionTypes.DOCUMENT_REMOVED: {
+      const { documentId, projectId } = action
+      // Set loading to false
+      const byId = { ...state.loading.byId, [documentId]: false }
+      const listLoading = { ...state.loading.byProject, [projectId]: false }
+      // Remove from list
+      // create new object with [documentId] item left out - assigned to throwaway __ const
+      // eslint-disable-next-line no-unused-vars
+      const { [documentId]: ___, ...restDocumentList } = state.projectDocumentsById[projectId]
+      const list = { ...state.projectDocumentsById, [projectId]: restDocumentList }
+      // Remove from documentsById
+      // eslint-disable-next-line no-unused-vars
+      const { [documentId]: __, documentsById } = state.documentsById
+      return {
+        ...state,
+        list,
+        documentsById,
+        loading: {
+          ...state.loading,
+          list: listLoading,
+          byId
+        }
+      }
+    }
     default:
       return state
   }

--- a/web/src/client/js/reducers/documents.js
+++ b/web/src/client/js/reducers/documents.js
@@ -114,24 +114,18 @@ export const documents = (state = initialState, action) => {
     }
     case ActionTypes.DOCUMENT_REMOVED: {
       const { documentId, projectId } = action
-      // Set loading to false
       const byId = { ...state.loading.byId, [documentId]: false }
-      const listLoading = { ...state.loading.byProject, [projectId]: false }
-      // Remove from list
+      const byProject = { ...state.loading.byProject, [projectId]: false }
       // create new object with [documentId] item left out - assigned to throwaway __ const
       // eslint-disable-next-line no-unused-vars
       const { [documentId]: ___, ...restDocumentList } = state.projectDocumentsById[projectId]
-      const list = { ...state.projectDocumentsById, [projectId]: restDocumentList }
-      // Remove from documentsById
-      // eslint-disable-next-line no-unused-vars
-      const { [documentId]: __, documentsById } = state.documentsById
+      const projectDocumentsById = { ...state.projectDocumentsById, [projectId]: restDocumentList }
       return {
         ...state,
-        list,
-        documentsById,
+        projectDocumentsById,
         loading: {
           ...state.loading,
-          list: listLoading,
+          byProject,
           byId
         }
       }

--- a/web/src/client/js/reducers/documents.js
+++ b/web/src/client/js/reducers/documents.js
@@ -79,7 +79,7 @@ export const documents = (state = initialState, action) => {
         }
       }
     }
-    case ActionTypes.INITIATE_UPDATE_DOCUMENT: {
+    case ActionTypes.INITIATE_DOCUMENT_UPDATE: {
       const byId = { ...state.loading.byId, [action.documentId]: true }
       const byProject = { ...state.loading.byProject, [action.projectId]: true }
       return {
@@ -112,7 +112,7 @@ export const documents = (state = initialState, action) => {
         }
       }
     }
-    case ActionTypes.DOCUMENT_REMOVED: {
+    case ActionTypes.REMOVE_DOCUMENT: {
       const { documentId, projectId } = action
       const byId = { ...state.loading.byId, [documentId]: false }
       const byProject = { ...state.loading.byProject, [projectId]: false }

--- a/web/src/client/js/sections/Project/ProjectSection.scss
+++ b/web/src/client/js/sections/Project/ProjectSection.scss
@@ -17,7 +17,6 @@
       height: calc(100vh - #{$ribbonHeight + $headerHeight});
       overflow-y: auto;
       overscroll-behavior: contain;
-      transform: translateZ(0);
       width: calc(#{$sideGutterWidth} + 300px);
       -webkit-overflow-scrolling: touch;
     }

--- a/web/src/client/js/sections/Project/ProjectSection.scss
+++ b/web/src/client/js/sections/Project/ProjectSection.scss
@@ -17,6 +17,7 @@
       height: calc(100vh - #{$ribbonHeight + $headerHeight});
       overflow-y: auto;
       overscroll-behavior: contain;
+      transform: translateZ(0);
       width: calc(#{$sideGutterWidth} + 300px);
       -webkit-overflow-scrolling: touch;
     }


### PR DESCRIPTION
* Adds delete action and ui
* Removes the separate list/documentsById in documents reducer, only using projectDocumentsById
* Changes babelrc targets to browsers, instead of Node. Was getting bizarre behavior with the destructuring in the reducer where documents wouldn't remove from state