### PR TITLE
updated update schemas

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -105,7 +105,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewProject'
+              $ref: '#/components/schemas/UpdateProject'
       responses:
         '200':
           description: project response
@@ -266,7 +266,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewDocument'
+              $ref: '#/components/schemas/UpdateDocument'
       responses:
         '200':
           description: document response
@@ -359,6 +359,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/NewField'
+            example:
+              name: field name
+              value: 808
+              type: 3
       responses:
         '201':
           description: field response
@@ -432,7 +436,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewField'
+              $ref: '#/components/schemas/UpdateField'
+            example:
+              value: "update value"
       responses:
         '200':
           description: field response
@@ -500,6 +506,15 @@ components:
       properties:
         name:
           type: string
+        description:
+          type: string
+
+    UpdateProject:
+      properties:
+        name:
+          type: string
+        description:
+          type: string
 
     Document:
       allOf:
@@ -521,6 +536,11 @@ components:
     NewDocument:
       required:
         - name
+      properties:
+        name:
+          type: string
+
+    UpdateDocument:
       properties:
         name:
           type: string
@@ -551,6 +571,13 @@ components:
         - $ref: '#/components/schemas/StringField'
         - $ref: '#/components/schemas/TextField'
         - $ref: '#/components/schemas/NumberField'
+
+    UpdateField:
+      properties:
+        value:
+          oneOf:
+            - type: string
+            - type: number
 
     StringField:
       required:

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -438,7 +438,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateField'
             example:
-              value: "update value"
+              name: "new name"
+              value: "new value"
       responses:
         '200':
           description: field response
@@ -489,8 +490,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/NewProject'
         - required:
-            - id
-          properties:
+          - id
+        - properties:
             id:
               type: integer
             createdAt:
@@ -520,8 +521,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/NewDocument'
         - required:
-            - id
-          properties:
+          - id
+          - projectId
+        - properties:
             id:
               type: integer
             projectId:
@@ -549,15 +551,22 @@ components:
       allOf:
         - $ref: '#/components/schemas/NewField'
         - required:
-            - id
-          properties:
+          - id
+          - name
+          - docId
+          - type
+        - properties:
             id:
               type: integer
+            name:
+              type: string
             docId:
               type: integer
             type:
               type: integer
             value:
+              type: string
+            structuredValue:
               type: string
             createdAt:
               type: string
@@ -574,6 +583,8 @@ components:
 
     UpdateField:
       properties:
+        name:
+          type: string
         value:
           oneOf:
             - type: string
@@ -583,7 +594,6 @@ components:
       required:
           - name
           - type
-          - value
       properties:
         name:
           type: string
@@ -597,7 +607,6 @@ components:
       required:
         - name
         - type
-        - value
       properties:
         name:
           type: string
@@ -613,7 +622,6 @@ components:
       required:
           - name
           - type
-          - value
       properties:
         name:
           type: string

--- a/api/src/businesstime/field.test-i.js
+++ b/api/src/businesstime/field.test-i.js
@@ -41,9 +41,8 @@ describe('BusinessField', () => {
     describe('when the parent document does not exist', () => {
       it('should throw an error', async () => {
         await expect(
-          BusinessField.createForDocument(factoryDocument.id, {
-            ...fieldBody,
-            docId: 0
+          BusinessField.createForDocument(0, {
+            ...fieldBody
           })
         ).rejects.toThrow()
       })

--- a/api/src/businesstime/field.test-i.js
+++ b/api/src/businesstime/field.test-i.js
@@ -48,17 +48,6 @@ describe('BusinessField', () => {
         ).rejects.toThrow()
       })
     })
-
-    describe('when the passed in docId does not match the body docId', () => {
-      it('should throw an error', async () => {
-        await expect(
-          BusinessField.createForDocument(factoryDocument.id, {
-            ...fieldBody,
-            docId: 0
-          })
-        ).rejects.toThrow()
-      })
-    })
   })
 
   describe('#updateByIdForDocument', () => {
@@ -120,17 +109,6 @@ describe('BusinessField', () => {
       it('should throw an error', async () => {
         await expect(
           BusinessField.updateByIdForDocument(fieldId, docId, 0, updateBody)
-        ).rejects.toThrow()
-      })
-    })
-
-    describe('when the passed in docId does not match the body docId', () => {
-      it('should throw an error', async () => {
-        await expect(
-          BusinessField.updateByIdForDocument(fieldId, docId, orgId, {
-            ...updateBody,
-            docId: 0
-          })
         ).rejects.toThrow()
       })
     })

--- a/api/src/controllers/documentFields.js
+++ b/api/src/controllers/documentFields.js
@@ -5,31 +5,12 @@ import { validateBody, validateParams } from '../libs/middleware/payloadValidati
 import BusinessField from '../businesstime/field'
 import crudPerms from '../libs/middleware/reqCrudPerms'
 import RESOURCE_TYPES from '../constants/resourceTypes'
-import fieldTypes from '../constants/fieldTypes'
+import { requiredFields, partialFields } from './payloadSchemas/helpers'
 
 const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
   RESOURCE_TYPES.DOCUMENT,
   req => req.params.documentId
 )
-
-const bodySchema = Joi.compile({
-  name: Joi.string().required(),
-  docId: Joi.number(),
-  value: Joi.alternatives(Joi.string(), Joi.number()).allow(null),
-  // TODO: probably want a shared json parse validator on structuredValue
-  structuredValue: Joi.string().allow(null),
-  type: Joi.number()
-    .valid(Object.values(fieldTypes.FIELD_TYPES))
-    .required()
-  // TODO: order: need to decide how to handle this
-})
-
-const bodyUpdateSchema = Joi.compile({
-  name: Joi.string(),
-  value: Joi.alternatives(Joi.string(), Joi.number()).allow(null),
-  // TODO: probably want a shared json parse validator on structuredValue
-  structuredValue: Joi.string().allow(null)
-})
 
 const paramSchema = Joi.compile({
   documentId: Joi.number().required(),
@@ -42,7 +23,7 @@ const projectDocumentsController = function(router) {
   router.post(
     '/',
     validateParams(paramSchema),
-    validateBody(bodySchema),
+    validateBody(requiredFields('field', 'name', 'type')),
     createPerm,
     addDocumentField
   )
@@ -51,7 +32,7 @@ const projectDocumentsController = function(router) {
   router.put(
     '/:id',
     validateParams(paramSchema),
-    validateBody(bodyUpdateSchema),
+    validateBody(partialFields('field', 'name', 'value', 'structuredValue')),
     updatePerm,
     updateDocumentField
   )

--- a/api/src/controllers/documentFields.js
+++ b/api/src/controllers/documentFields.js
@@ -15,13 +15,20 @@ const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
 const bodySchema = Joi.compile({
   name: Joi.string().required(),
   docId: Joi.number(),
-  value: Joi.alternatives(Joi.string(), Joi.number()).required(),
-  // TODO: probably want a json parse validator on this one
-  structuredValue: Joi.string(),
+  value: Joi.alternatives(Joi.string(), Joi.number()).allow(null),
+  // TODO: probably want a shared json parse validator on structuredValue
+  structuredValue: Joi.string().allow(null),
   type: Joi.number()
     .valid(Object.values(fieldTypes.FIELD_TYPES))
     .required()
   // TODO: order: need to decide how to handle this
+})
+
+const bodyUpdateSchema = Joi.compile({
+  name: Joi.string(),
+  value: Joi.alternatives(Joi.string(), Joi.number()).allow(null),
+  // TODO: probably want a shared json parse validator on structuredValue
+  structuredValue: Joi.string().allow(null)
 })
 
 const paramSchema = Joi.compile({
@@ -44,7 +51,7 @@ const projectDocumentsController = function(router) {
   router.put(
     '/:id',
     validateParams(paramSchema),
-    validateBody(bodySchema),
+    validateBody(bodyUpdateSchema),
     updatePerm,
     updateDocumentField
   )

--- a/api/src/controllers/payloadSchemas/document.js
+++ b/api/src/controllers/payloadSchemas/document.js
@@ -1,0 +1,7 @@
+import Joi from 'joi'
+
+export const rawSchema = {
+  name: Joi.string()
+}
+
+export default Joi.compile(rawSchema)

--- a/api/src/controllers/payloadSchemas/field.js
+++ b/api/src/controllers/payloadSchemas/field.js
@@ -3,7 +3,6 @@ import fieldTypes from '../../constants/fieldTypes'
 
 export const rawSchema = {
   name: Joi.string(),
-  docId: Joi.number(),
   value: Joi.alternatives(Joi.string(), Joi.number()).allow(null),
   // TODO: probably want a shared json parse validator on structuredValue
   structuredValue: Joi.string().allow(null),

--- a/api/src/controllers/payloadSchemas/field.js
+++ b/api/src/controllers/payloadSchemas/field.js
@@ -1,0 +1,15 @@
+import Joi from 'joi'
+import fieldTypes from '../../constants/fieldTypes'
+
+export const rawSchema = {
+  name: Joi.string(),
+  docId: Joi.number(),
+  value: Joi.alternatives(Joi.string(), Joi.number()).allow(null),
+  // TODO: probably want a shared json parse validator on structuredValue
+  structuredValue: Joi.string().allow(null),
+  type: Joi.number()
+    .valid(Object.values(fieldTypes.FIELD_TYPES))
+  // TODO: order: need to decide how to handle this
+}
+
+export default Joi.compile(rawSchema)

--- a/api/src/controllers/payloadSchemas/helpers.js
+++ b/api/src/controllers/payloadSchemas/helpers.js
@@ -1,8 +1,10 @@
 import Joi from 'joi'
 import * as user from './user'
+import * as project from './project'
 
 const resourceToSchema = {
-  user
+  user,
+  project
 }
 
 /**

--- a/api/src/controllers/payloadSchemas/project.js
+++ b/api/src/controllers/payloadSchemas/project.js
@@ -1,0 +1,8 @@
+import Joi from 'joi'
+
+export const rawSchema = {
+  name: Joi.string(),
+  description: Joi.string().allow('').allow(null)
+}
+
+export default Joi.compile(rawSchema)

--- a/api/src/controllers/projectDocuments.js
+++ b/api/src/controllers/projectDocuments.js
@@ -14,8 +14,7 @@ const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
 // does it need its own, or will it always be the same?
 
 const bodySchema = Joi.compile({
-  name: Joi.string().required(),
-  projectId: Joi.number()
+  name: Joi.string().required()
 })
 
 const paramSchema = Joi.compile({

--- a/api/src/controllers/projectDocuments.js
+++ b/api/src/controllers/projectDocuments.js
@@ -4,18 +4,15 @@ import { validateBody, validateParams } from '../libs/middleware/payloadValidati
 import BusinessDocument from '../businesstime/document'
 import crudPerms from '../libs/middleware/reqCrudPerms'
 import RESOURCE_TYPES from '../constants/resourceTypes'
+import { requiredFields } from './payloadSchemas/helpers'
+import documentSchema from './payloadSchemas/document'
 
 const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
   RESOURCE_TYPES.PROJECT,
   req => req.params.projectId
 )
 
-// TODO: this is currently piggybacking off of project perms,
-// does it need its own, or will it always be the same?
-
-const bodySchema = Joi.compile({
-  name: Joi.string().required()
-})
+// TODO: this is currently piggybacking off of project perms
 
 const paramSchema = Joi.compile({
   projectId: Joi.number().required(),
@@ -27,7 +24,7 @@ const projectDocumentsController = function(router) {
   router.post(
     '/',
     validateParams(paramSchema),
-    validateBody(bodySchema),
+    validateBody(requiredFields('document', 'name')),
     createPerm,
     addProjectDocument
   )
@@ -36,7 +33,7 @@ const projectDocumentsController = function(router) {
   router.put(
     '/:id',
     validateParams(paramSchema),
-    validateBody(bodySchema),
+    validateBody(documentSchema),
     updatePerm,
     replaceProjectDocument
   )

--- a/api/src/controllers/projects.js
+++ b/api/src/controllers/projects.js
@@ -1,25 +1,21 @@
-import Joi from 'joi'
 import ono from 'ono'
 import { validateBody } from '../libs/middleware/payloadValidation'
 import BusinessProject from '../businesstime/project'
 import crudPerms from '../libs/middleware/reqCrudPerms'
 import RESOURCE_TYPES from '../constants/resourceTypes'
+import { requiredFields } from './payloadSchemas/helpers'
+import projectSchema from './payloadSchemas/project'
 
 const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
   RESOURCE_TYPES.PROJECT,
   req => req.params.id
 )
 
-const projectsPayloadSchema = Joi.compile({
-  name: Joi.string().required(),
-  description: Joi.string().allow('')
-})
-
 const projectsController = function(router) {
-  router.post('/', validateBody(projectsPayloadSchema), createPerm, addProject)
+  router.post('/', validateBody(requiredFields('project', 'name')), createPerm, addProject)
   router.get('/', listPerm, getProjects)
   router.get('/:id', readPerm, getProject)
-  router.put('/:id', validateBody(projectsPayloadSchema), updatePerm, replaceProject)
+  router.put('/:id', validateBody(projectSchema), updatePerm, replaceProject)
   router.delete('/:id', deletePerm, deleteProject)
 }
 

--- a/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
@@ -18,8 +18,7 @@ const DocumentsListContainer = ({ createDocument, uiDocumentCreate, history, ui,
 
   function createDocumentAction(value) {
     createDocument(match.params.projectId, history, {
-      name: value,
-      projectId: match.params.projectId
+      name: value
     })
   }
 


### PR DESCRIPTION
- allows empty field values on creation
- breaks out create and update schemas using helpers
- partialFields schema helper
- updates documentation

NOTE: the previous swagger viewer I suggested wasn't showing payload examples, use `OpenAPI Preview` extension instead
