### PR TITLE
Refactor BusinessTimey™ layers to remove orgId

### DIFF
--- a/api/src/businesstime/document.js
+++ b/api/src/businesstime/document.js
@@ -71,10 +71,9 @@ async function findParentProjectByDocumentId(id, orgId) {
     .model(MODEL_NAME)
     .findOne({ where: { id, orgId }, include: [{ model: db.model('Project') }] })
 
-  //TODO: figure out how to get this project to just return public fields
-  // I don't want business layers to require each other, that's asking for
-  // circular funtime requires
-  return document.Project && document.Project.get({ plain: true })
+  const project = document.Project && document.Project.get({ plain: true })
+
+  return pick(project, resourcePublicFields[resourceTypes.PROJECT])
 }
 
 export default {

--- a/api/src/businesstime/document.test-i.js
+++ b/api/src/businesstime/document.test-i.js
@@ -18,7 +18,7 @@ describe('BusinessDocument', () => {
   describe('#createForProject', () => {
     const documentBody = {
       name: 'test-document',
-      orgId: constants.ORG_ID,
+      orgId: constants.ORG_ID
     }
     let document
 

--- a/api/src/businesstime/document.test-i.js
+++ b/api/src/businesstime/document.test-i.js
@@ -16,21 +16,21 @@ describe('BusinessDocument', () => {
   describe('#createForProject', () => {
     const documentBody = {
       name: 'test-document',
-      orgId: constants.ORG_ID
+      orgId: constants.ORG_ID,
     }
     let document
 
     beforeAll(async () => {
       document = await BusinessDocument.createForProject(factoryProject.id, {
-        ...documentBody,
-        projectId: factoryProject.id
+        ...documentBody
       })
     })
 
     it('should return the saved document as a POJO', () => {
-      expect(document).toEqual(expect.objectContaining(documentBody))
+      // eslint-disable-next-line no-unused-vars
+      const { orgId, ...expectedBody } = documentBody
+      expect(document).toEqual(expect.objectContaining(expectedBody))
       expect(document.constructor).toBe(Object)
-      expect(document.orgId).toBe(constants.ORG_ID)
     })
 
     describe('when the parent project does not exist', () => {
@@ -135,7 +135,7 @@ describe('BusinessDocument', () => {
         for (const document of documents) {
           expect(document.password).toBe(undefined)
           expect(document.constructor).toBe(Object)
-          expect(document.orgId).toBe(constants.ORG_ID)
+          expect(typeof document.projectId).toBe('number')
         }
       })
     })
@@ -157,7 +157,7 @@ describe('BusinessDocument', () => {
         it('should return a document as POJO', () => {
           expect(document.id).toBe(targetDocumentId)
           expect(document.constructor).toBe(Object)
-          expect(document.orgId).toBe(constants.ORG_ID)
+          expect(document.projectId).toBe(factoryProject.id)
         })
       })
 

--- a/api/src/businesstime/document.test-i.js
+++ b/api/src/businesstime/document.test-i.js
@@ -3,6 +3,8 @@ import ProjectFactory from '../db/__testSetup__/factories/project'
 import DocumentFactory from '../db/__testSetup__/factories/document'
 import initializeTestDb, { clearDb } from '../db/__testSetup__/initializeTestDb'
 import constants from '../db/__testSetup__/constants'
+import resourceTypes from '../constants/resourceTypes'
+import resourcePublicFields from '../constants/resourcePublicFields'
 
 describe('BusinessDocument', () => {
   let factoryProject
@@ -256,6 +258,7 @@ describe('BusinessDocument', () => {
 
     it('should return the parent project of passed in document', () => {
       expect(project.id).toEqual(factoryProject.id)
+      expect(Object.keys(project)).toEqual(expect.arrayContaining(resourcePublicFields[resourceTypes.PROJECT]))
     })
   })
 })

--- a/api/src/businesstime/field.test-i.js
+++ b/api/src/businesstime/field.test-i.js
@@ -4,6 +4,8 @@ import DocumentFactory from '../db/__testSetup__/factories/document'
 import FieldFactory from '../db/__testSetup__/factories/field'
 import initializeTestDb, { clearDb } from '../db/__testSetup__/initializeTestDb'
 import constants from '../db/__testSetup__/constants'
+import resourceTypes from '../constants/resourceTypes'
+import resourcePublicFields from '../constants/resourcePublicFields'
 
 describe('BusinessField', () => {
   let factoryProject
@@ -33,9 +35,11 @@ describe('BusinessField', () => {
     })
 
     it('should return the saved field as a POJO', () => {
-      expect(field).toEqual(expect.objectContaining(fieldBody))
+      // eslint-disable-next-line no-unused-vars
+      const { orgId, ...expectedBody } = fieldBody
+      expect(field).toEqual(expect.objectContaining(expectedBody))
       expect(field.constructor).toBe(Object)
-      expect(field.orgId).toBe(constants.ORG_ID)
+      expect(Object.keys(field)).toEqual(expect.arrayContaining(resourcePublicFields[resourceTypes.FIELD]))
     })
 
     describe('when the parent document does not exist', () => {
@@ -138,7 +142,7 @@ describe('BusinessField', () => {
       it('should return fields as POJOs', () => {
         for (const field of fields) {
           expect(field.constructor).toBe(Object)
-          expect(field.orgId).toBe(constants.ORG_ID)
+          expect(Object.keys(field)).toEqual(expect.arrayContaining(resourcePublicFields[resourceTypes.FIELD]))
         }
       })
     })
@@ -160,7 +164,7 @@ describe('BusinessField', () => {
         it('should return a field as POJO', () => {
           expect(field.id).toBe(targetFieldId)
           expect(field.constructor).toBe(Object)
-          expect(field.orgId).toBe(constants.ORG_ID)
+          expect(Object.keys(field)).toEqual(expect.arrayContaining(resourcePublicFields[resourceTypes.FIELD]))
         })
       })
 

--- a/api/src/businesstime/project.js
+++ b/api/src/businesstime/project.js
@@ -32,7 +32,8 @@ async function findById(id, orgId) {
   return await db.model(MODEL_NAME).findOne({
     attributes: PUBLIC_FIELDS,
     where: { id, orgId },
-    raw: true })
+    raw: true
+  })
 }
 
 async function updateById(id, body, orgId) {

--- a/api/src/businesstime/project.js
+++ b/api/src/businesstime/project.js
@@ -1,22 +1,38 @@
 import { getDb } from '../db/dbConnector'
 import ono from 'ono'
+import resourceTypes from '../constants/resourceTypes'
+import resourcePublicFields from '../constants/resourcePublicFields'
+import { pick } from '../libs/utils'
 
 const MODEL_NAME = 'Project'
+
+const PUBLIC_FIELDS = resourcePublicFields[resourceTypes.PROJECT]
+
+const publicFields = (instance) => {
+  return pick(instance, PUBLIC_FIELDS)
+}
 
 async function create(body) {
   const db = getDb()
   const createdProject = await db.model(MODEL_NAME).create(body)
-  return createdProject.get({ plain: true })
+  return publicFields(createdProject)
 }
 
 async function findAll(orgId) {
   const db = getDb()
-  return await db.model(MODEL_NAME).findAll({ where: { orgId }, raw: true })
+  return await db.model(MODEL_NAME).findAll({
+    attributes: PUBLIC_FIELDS,
+    where: { orgId },
+    raw: true
+  })
 }
 
 async function findById(id, orgId) {
   const db = getDb()
-  return await db.model(MODEL_NAME).findOne({ where: { id, orgId }, raw: true })
+  return await db.model(MODEL_NAME).findOne({
+    attributes: PUBLIC_FIELDS,
+    where: { id, orgId },
+    raw: true })
 }
 
 async function updateById(id, body, orgId) {
@@ -26,7 +42,7 @@ async function updateById(id, body, orgId) {
   if (!project) throw ono({ code: 404 }, `Cannot update, project not found with id: ${id}`)
 
   const updatedProject = await project.update(body)
-  return updatedProject.get({ plain: true })
+  return publicFields(updatedProject)
 }
 
 async function deleteById(id, orgId) {

--- a/api/src/businesstime/project.test-i.js
+++ b/api/src/businesstime/project.test-i.js
@@ -2,6 +2,10 @@ import BusinessProject from './project'
 import ProjectFactory from '../db/__testSetup__/factories/project'
 import initializeTestDb, { clearDb } from '../db/__testSetup__/initializeTestDb'
 import constants from '../db/__testSetup__/constants'
+import resourceTypes from '../constants/resourceTypes'
+import resourcePublicFields from '../constants/resourcePublicFields'
+
+const PUBLIC_FIELDS = resourcePublicFields[resourceTypes.PROJECT]
 
 describe('BusinessProject', () => {
   beforeAll(async () => {
@@ -17,9 +21,10 @@ describe('BusinessProject', () => {
     })
 
     it('should return the saved project as a POJO', () => {
-      expect(project).toEqual(expect.objectContaining(projectBody))
+      // eslint-disable-next-line no-unused-vars
+      const { orgId, ...expectedBody } = projectBody
+      expect(project).toEqual(expect.objectContaining(expectedBody))
       expect(project.constructor).toBe(Object)
-      expect(project.orgId).toBe(constants.ORG_ID)
     })
   })
 
@@ -74,7 +79,7 @@ describe('BusinessProject', () => {
         for (const project of projects) {
           expect(project.password).toBe(undefined)
           expect(project.constructor).toBe(Object)
-          expect(project.orgId).toBe(constants.ORG_ID)
+          expect(Object.keys(project)).toEqual(expect.arrayContaining(PUBLIC_FIELDS))
         }
       })
     })
@@ -92,7 +97,7 @@ describe('BusinessProject', () => {
         it('should return a project as POJO', () => {
           expect(project.id).toBe(targetProjectId)
           expect(project.constructor).toBe(Object)
-          expect(project.orgId).toBe(constants.ORG_ID)
+          expect(Object.keys(project)).toEqual(expect.arrayContaining(PUBLIC_FIELDS))
         })
       })
 

--- a/api/src/businesstime/projectuser.js
+++ b/api/src/businesstime/projectuser.js
@@ -1,9 +1,16 @@
 import { getDb } from '../db/dbConnector'
 import ono from 'ono'
+import resourceTypes from '../constants/resourceTypes'
+import resourcePublicFields from '../constants/resourcePublicFields'
+import { pick } from '../libs/utils'
 
 const MODEL_NAME = 'ProjectUser'
 
-export const PUBLIC_FIELDS = ['id', 'roleId', 'projectId', 'userId']
+const PUBLIC_FIELDS = resourcePublicFields[resourceTypes.PROJECT_USER]
+
+const publicFields = (instance) => {
+  return pick(instance, PUBLIC_FIELDS)
+}
 
 async function create(body) {
   const db = getDb()
@@ -52,9 +59,9 @@ async function updateProjectUserById(id, roleId, orgId) {
   if (!projectUser) {
     throw ono({ code: 404 }, `Project user assignment id ${id} not found`)
   }
-  return (await projectUser.update({
+  return publicFields(await projectUser.update({
     roleId
-  })).get({ plain: true })
+  }))
 }
 
 async function findAllByProjectId(projectId, orgId) {
@@ -107,7 +114,10 @@ async function removeAllUsersFromProject(projectId, orgId) {
 
 async function getProjectUserAssignment(userId, projectId, orgId) {
   const db = getDb()
-  return await db.model(MODEL_NAME).findOne({ where: { userId, projectId, orgId } })
+  return await db.model(MODEL_NAME).findOne({
+    attributes: PUBLIC_FIELDS,
+    where: { userId, projectId, orgId }
+  })
 }
 
 export default {

--- a/api/src/businesstime/projectuser.test-i.js
+++ b/api/src/businesstime/projectuser.test-i.js
@@ -1,8 +1,12 @@
-import BusinessProjectUser, { PUBLIC_FIELDS } from './projectuser'
+import BusinessProjectUser from './projectuser'
 import ProjectFactory from '../db/__testSetup__/factories/project'
 import UserFactory from '../db/__testSetup__/factories/user'
 import initializeTestDb, { clearDb } from '../db/__testSetup__/initializeTestDb'
 import constants from '../db/__testSetup__/constants'
+import resourceTypes from '../constants/resourceTypes'
+import resourcePublicFields from '../constants/resourcePublicFields'
+
+const PUBLIC_FIELDS = resourcePublicFields[resourceTypes.PROJECT_USER]
 
 describe('BusinessProjectUser', () => {
   beforeAll(async () => {

--- a/api/src/businesstime/user.test-i.js
+++ b/api/src/businesstime/user.test-i.js
@@ -3,6 +3,8 @@ import UserFactory from '../db/__testSetup__/factories/user'
 import initializeTestDb, { clearDb } from '../db/__testSetup__/initializeTestDb'
 import constants from '../db/__testSetup__/constants'
 import { ORGANIZATION_ROLE_IDS } from '../constants/roles'
+import resourceTypes from '../constants/resourceTypes'
+import resourcePublicFields from '../constants/resourcePublicFields'
 
 describe('BusinessUser', () => {
   beforeAll(async () => {
@@ -24,7 +26,9 @@ describe('BusinessUser', () => {
     })
 
     it('should return the saved user as a POJO', () => {
-      expect(user).toEqual(expect.objectContaining(userBody))
+      // eslint-disable-next-line no-unused-vars
+      const { orgId, ...expectedBody } = userBody
+      expect(user).toEqual(expect.objectContaining(expectedBody))
       expect(user.constructor).toBe(Object)
     })
   })
@@ -153,7 +157,7 @@ describe('BusinessUser', () => {
           expect(user.password).toBe(undefined)
           expect(user.id).toBe(targetUserId)
           expect(user.constructor).toBe(Object)
-          expect(user.orgId).toBe(constants.ORG_ID)
+          expect(Object.keys(user)).toEqual(expect.arrayContaining(resourcePublicFields[resourceTypes.USER]))
         })
       })
 

--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -16,8 +16,15 @@ const FIELD_PUBLIC_FIELDS = [
   'order'
 ].concat(globalPublicFields)
 
+const PROJECT_USERS_PUBLIC_FIELDS = ['id', 'roleId', 'projectId', 'userId'].concat(globalPublicFields)
+
+const USER_PUBLIC_FIELDS = ['firstName', 'lastName', 'email', 'orgRoleId'].concat(globalPublicFields)
+
+
 export default {
   [resourceTypes.DOCUMENT]: DOCUMENT_PUBLIC_FIELDS,
   [resourceTypes.PROJECT]: PROJECT_PUBLIC_FIELDS,
-  [resourceTypes.FIELD]: FIELD_PUBLIC_FIELDS
+  [resourceTypes.FIELD]: FIELD_PUBLIC_FIELDS,
+  [resourceTypes.PROJECT_USER]: PROJECT_USERS_PUBLIC_FIELDS,
+  [resourceTypes.PROJECT_USER]: USER_PUBLIC_FIELDS
 }

--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -4,6 +4,9 @@ import globalPublicFields from './globalPublicFields'
 
 const DOCUMENT_PUBLIC_FIELDS = ['name', 'publishedVersionId', 'projectId'].concat(globalPublicFields)
 
+const PROJECT_PUBLIC_FIELDS = ['name', 'description'].concat(globalPublicFields)
+
 export default {
-  [resourceTypes.DOCUMENT]: DOCUMENT_PUBLIC_FIELDS
+  [resourceTypes.DOCUMENT]: DOCUMENT_PUBLIC_FIELDS,
+  [resourceTypes.PROJECT]: PROJECT_PUBLIC_FIELDS
 }

--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -26,5 +26,5 @@ export default {
   [resourceTypes.PROJECT]: PROJECT_PUBLIC_FIELDS,
   [resourceTypes.FIELD]: FIELD_PUBLIC_FIELDS,
   [resourceTypes.PROJECT_USER]: PROJECT_USERS_PUBLIC_FIELDS,
-  [resourceTypes.PROJECT_USER]: USER_PUBLIC_FIELDS
+  [resourceTypes.USER]: USER_PUBLIC_FIELDS
 }

--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -6,7 +6,18 @@ const DOCUMENT_PUBLIC_FIELDS = ['name', 'publishedVersionId', 'projectId'].conca
 
 const PROJECT_PUBLIC_FIELDS = ['name', 'description'].concat(globalPublicFields)
 
+const FIELD_PUBLIC_FIELDS = [
+  'name',
+  'value',
+  'structuredValue',
+  'docId',
+  'versionId',
+  'type',
+  'order'
+].concat(globalPublicFields)
+
 export default {
   [resourceTypes.DOCUMENT]: DOCUMENT_PUBLIC_FIELDS,
-  [resourceTypes.PROJECT]: PROJECT_PUBLIC_FIELDS
+  [resourceTypes.PROJECT]: PROJECT_PUBLIC_FIELDS,
+  [resourceTypes.FIELD]: FIELD_PUBLIC_FIELDS
 }

--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -1,0 +1,9 @@
+
+import resourceTypes from './resourceTypes'
+import globalPublicFields from './globalPublicFields'
+
+const DOCUMENT_PUBLIC_FIELDS = ['name', 'publishedVersionId', 'projectId'].concat(globalPublicFields)
+
+export default {
+  [resourceTypes.DOCUMENT]: DOCUMENT_PUBLIC_FIELDS
+}

--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -22,9 +22,9 @@ const USER_PUBLIC_FIELDS = ['firstName', 'lastName', 'email', 'orgRoleId'].conca
 
 
 export default {
-  [resourceTypes.DOCUMENT]: DOCUMENT_PUBLIC_FIELDS,
-  [resourceTypes.PROJECT]: PROJECT_PUBLIC_FIELDS,
-  [resourceTypes.FIELD]: FIELD_PUBLIC_FIELDS,
-  [resourceTypes.PROJECT_USER]: PROJECT_USERS_PUBLIC_FIELDS,
-  [resourceTypes.USER]: USER_PUBLIC_FIELDS
+  [resourceTypes.DOCUMENT]: Object.freeze(DOCUMENT_PUBLIC_FIELDS),
+  [resourceTypes.PROJECT]: Object.freeze(PROJECT_PUBLIC_FIELDS),
+  [resourceTypes.FIELD]: Object.freeze(FIELD_PUBLIC_FIELDS),
+  [resourceTypes.PROJECT_USER]: Object.freeze(PROJECT_USERS_PUBLIC_FIELDS),
+  [resourceTypes.USER]: Object.freeze(USER_PUBLIC_FIELDS)
 }

--- a/api/src/controllers/documentFields.js
+++ b/api/src/controllers/documentFields.js
@@ -9,7 +9,7 @@ import { requiredFields, partialFields } from './payloadSchemas/helpers'
 
 const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
   RESOURCE_TYPES.DOCUMENT,
-  req => {
+  (req) => {
     return { documentId: req.params.documentId }
   }
 )

--- a/api/src/controllers/payloadSchemas/helpers.js
+++ b/api/src/controllers/payloadSchemas/helpers.js
@@ -25,7 +25,7 @@ const requiredFields = (resource, ...fields) => {
 
   const rawSchema = resourceToSchema[resource].rawSchema
   const schema = { ...rawSchema }
-  fields.forEach(field => {
+  fields.forEach((field) => {
     if (schema.hasOwnProperty(field)) {
       schema[field] = schema[field].required()
     } else {
@@ -58,7 +58,7 @@ const partialFields = (resource, ...fields) => {
   return Joi.compile(schema)
 }
 
-const verifyResource = resource => {
+const verifyResource = (resource) => {
   if (!resourceToSchema.hasOwnProperty(resource)) {
     throw new Error(
       `Resource ${resource} does not have a defined payloadSchema.` +

--- a/api/src/controllers/projectDocuments.js
+++ b/api/src/controllers/projectDocuments.js
@@ -9,7 +9,7 @@ import documentSchema from './payloadSchemas/document'
 
 const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
   RESOURCE_TYPES.DOCUMENT,
-  req => {
+  (req) => {
     return { projectId: req.params.projectId }
   }
 )

--- a/api/src/controllers/projects.js
+++ b/api/src/controllers/projects.js
@@ -9,7 +9,7 @@ import projectSchema from './payloadSchemas/project'
 
 const { listPerm, readPerm, createPerm, deletePerm, updatePerm } = crudPerms(
   RESOURCE_TYPES.PROJECT,
-  req => {
+  (req) => {
     return { id: req.params.id }
   }
 )

--- a/api/src/db/migrations/20190402152302-create-project-user.js
+++ b/api/src/db/migrations/20190402152302-create-project-user.js
@@ -30,6 +30,10 @@ module.exports = {
         createdAt: {
           allowNull: false,
           type: Sequelize.DATE
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE
         }
       })
       .then(() => {

--- a/api/src/db/models/projectuser.js
+++ b/api/src/db/models/projectuser.js
@@ -14,7 +14,6 @@ module.exports = (sequelize, DataTypes) => {
       roleId: DataTypes.INTEGER
     },
     {
-      updatedAt: false, // don't use updatedAt timestamp
       freezeTableName: true,
       tableName: 'ProjectsUsers'
     }

--- a/api/src/db/seeders/20190402213550-projectusers.js
+++ b/api/src/db/seeders/20190402213550-projectusers.js
@@ -6,6 +6,7 @@ const projectUsers = [
   {
     orgId: BONKEY_ORG_ID,
     createdAt: TODAY,
+    updatedAt: TODAY,
     projectId: BONKEY_PROJECT_ID,
     userId: BONKEY_USER_ID,
     roleId: 1

--- a/api/src/libs/utils.js
+++ b/api/src/libs/utils.js
@@ -1,0 +1,7 @@
+
+export const pick = (obj, fields) => {
+  return fields.reduce((pojo, field) => {
+    pojo[field] = obj[field]
+    return pojo
+  }, {})
+}


### PR DESCRIPTION
- Define public fields by resource type in constants
- BusinessTime returns the public fields from all functions, unless it's special like user with `sanitized` function returns