### PR TITLE
project token auth

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -5,7 +5,7 @@ import passport from 'passport'
 import logger from 'morgan'
 //libs
 import envVarValidation from './libs/envVarValidation'
-import auth from './libs/auth'
+import auth from './libs/auth/auth'
 import controllerLoader from './controllers/loader'
 
 // Check if required env vars are set the right format

--- a/api/src/businesstime/__mocks__/projecttoken.js
+++ b/api/src/businesstime/__mocks__/projecttoken.js
@@ -13,5 +13,8 @@ const getGenericMockTokenData = () => {
 export default {
   create: jest.fn(() => getGenericMockTokenData()),
   findById: jest.fn(() => getGenericMockTokenData()),
+  findByIdUnsanitized: jest.fn(() => {
+    return { ...getGenericMockTokenData(), secret: 'abc123' }
+  }),
   addTokenStringById: jest.fn(() => getGenericMockTokenData())
 }

--- a/api/src/businesstime/project.test-i.js
+++ b/api/src/businesstime/project.test-i.js
@@ -112,35 +112,6 @@ describe('BusinessProject', () => {
         })
       })
     })
-
-    describe('#findByIdUnsanitized', () => {
-      let targetProjectId
-      let project
-
-      describe('when the target project has the passed in orgId', () => {
-        beforeAll(async () => {
-          targetProjectId = factoryProjects[0].get('id')
-          project = await BusinessProject.findById(targetProjectId, constants.ORG_ID)
-        })
-
-        it('should return a project as POJO', () => {
-          expect(project.id).toBe(targetProjectId)
-          expect(project.constructor).toBe(Object)
-          expect(Object.keys(project)).toEqual(expect.arrayContaining(PUBLIC_FIELDS))
-        })
-      })
-
-      describe('when the target project does not have the passed in orgId', () => {
-        beforeAll(async () => {
-          targetProjectId = factoryProjects[0].get('id')
-          project = await BusinessProject.findById(targetProjectId, constants.ORG_ID_2)
-        })
-
-        it('should return null', () => {
-          expect(project).toBe(null)
-        })
-      })
-    })
   })
 
   describe('#deleteById', () => {

--- a/api/src/businesstime/project.test-i.js
+++ b/api/src/businesstime/project.test-i.js
@@ -112,6 +112,35 @@ describe('BusinessProject', () => {
         })
       })
     })
+
+    describe('#findByIdUnsanitized', () => {
+      let targetProjectId
+      let project
+
+      describe('when the target project has the passed in orgId', () => {
+        beforeAll(async () => {
+          targetProjectId = factoryProjects[0].get('id')
+          project = await BusinessProject.findById(targetProjectId, constants.ORG_ID)
+        })
+
+        it('should return a project as POJO', () => {
+          expect(project.id).toBe(targetProjectId)
+          expect(project.constructor).toBe(Object)
+          expect(Object.keys(project)).toEqual(expect.arrayContaining(PUBLIC_FIELDS))
+        })
+      })
+
+      describe('when the target project does not have the passed in orgId', () => {
+        beforeAll(async () => {
+          targetProjectId = factoryProjects[0].get('id')
+          project = await BusinessProject.findById(targetProjectId, constants.ORG_ID_2)
+        })
+
+        it('should return null', () => {
+          expect(project).toBe(null)
+        })
+      })
+    })
   })
 
   describe('#deleteById', () => {

--- a/api/src/businesstime/projecttoken.js
+++ b/api/src/businesstime/projecttoken.js
@@ -27,6 +27,15 @@ async function findById(id, orgId) {
   })
 }
 
+// To be used only internally!
+async function findByIdUnsanitized(id, orgId) {
+  const db = getDb()
+  return await db.model(MODEL_NAME).findOne({
+    where: { orgId, id },
+    raw: true
+  })
+}
+
 async function findAllByProjectId(projectId, orgId) {
   const db = getDb()
   const tokens = await db.model(MODEL_NAME).findAll({
@@ -76,6 +85,7 @@ async function deleteById(id, orgId) {
 export default {
   create,
   findById,
+  findByIdUnsanitized,
   findAllByProjectId,
   updateNameById,
   addTokenStringById,

--- a/api/src/businesstime/projecttoken.test-i.js
+++ b/api/src/businesstime/projecttoken.test-i.js
@@ -119,6 +119,27 @@ describe('BusinessProjectToken', () => {
     })
   })
 
+  describe('#findByIdUnsanitized', () => {
+    let token
+    let factoryToken
+    beforeAll(async () => {
+      factoryToken = (await TokenFactory.createMany(1, {
+        projectId: 123,
+        orgId: constants.ORG_ID
+      }))[0]
+
+      token = await BusinessProjectToken.findByIdUnsanitized(factoryToken.id, factoryToken.orgId)
+    })
+
+    it('should return public fields', () => {
+      expect(Object.keys(token)).toEqual(expect.arrayContaining(PUBLIC_FIELDS))
+    })
+
+    it('should return the secret', () => {
+      expect(token.secret).toBe(factoryToken.secret)
+    })
+  })
+
   describe('#addTokenStringById', () => {
     let updatedTokenString
     let updatedToken

--- a/api/src/controllers/loader.js
+++ b/api/src/controllers/loader.js
@@ -1,5 +1,5 @@
 import express from 'express'
-import auth from '../libs/auth'
+import auth from '../libs/auth/auth'
 import reqInfoExtractor from '../libs/middleware/reqInfoExtractorMiddleware'
 
 // To add a controller, add the base path to mount it as a key
@@ -64,7 +64,7 @@ const loadControllers = (router, controllers, middleware, routerOptions) => {
 }
 
 const loader = (router) => {
-  loadControllers(router, AUTHENTICATED_CONTROLLERS, [auth.jwtMiddleware, reqInfoExtractor])
+  loadControllers(router, AUTHENTICATED_CONTROLLERS, [auth.jwtMiddleware, auth.jwtProjectTokenMiddleware, reqInfoExtractor])
   loadControllers(router, UNAUTHENTICATED_CONTROLLERS)
 }
 

--- a/api/src/controllers/loader.js
+++ b/api/src/controllers/loader.js
@@ -64,7 +64,7 @@ const loadControllers = (router, controllers, middleware, routerOptions) => {
 }
 
 const loader = (router) => {
-  loadControllers(router, AUTHENTICATED_CONTROLLERS, [auth.jwtMiddleware, auth.jwtProjectTokenMiddleware, reqInfoExtractor])
+  loadControllers(router, AUTHENTICATED_CONTROLLERS, [auth.jwtMiddleware, reqInfoExtractor])
   loadControllers(router, UNAUTHENTICATED_CONTROLLERS)
 }
 

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -1,4 +1,4 @@
-import auth from '../libs/auth'
+import auth from '../libs/auth/auth'
 import tokenIntegrator from '../integrators/token'
 
 // Caution: login controller routes have NO AUTH by default!

--- a/api/src/controllers/signup.js
+++ b/api/src/controllers/signup.js
@@ -3,7 +3,7 @@ import Joi from 'joi'
 import { validateBody } from '../libs/middleware/payloadValidation'
 import signUpCoordinator from '../coordinators/signUp'
 import userCoordinator from '../coordinators/user'
-import auth from '../libs/auth'
+import auth from '../libs/auth/auth'
 
 const signupPayloadSchema = Joi.compile({
   firstName: Joi.string().required(),

--- a/api/src/coordinators/projectToken.js
+++ b/api/src/coordinators/projectToken.js
@@ -1,6 +1,8 @@
 import rsg from '../libs/randomStringGenerator'
 import tokenGenerator from '../integrators/token'
+import jwt from 'jsonwebtoken'
 import BusinessProjectToken from '../businesstime/projecttoken'
+import tokenSettings from '../libs/tokenSettings'
 
 const SECRET_SIZE = 20
 
@@ -17,4 +19,25 @@ export const createProjectToken = async ({ name, projectId, roleId }, orgId) => 
   const tokenString = await tokenGenerator.generateProjectToken(projectToken.id, secret, orgId)
 
   return await BusinessProjectToken.addTokenStringById(projectToken.id, tokenString, orgId)
+}
+
+export const verifyProjectToken = async (token) => {
+  const tokenData = jwt.decode(token)
+
+  const businessToken = await BusinessProjectToken.findByIdUnsanitized(tokenData.id, tokenData.orgId)
+  if (!businessToken) return false
+
+  const options = {
+    issuer: tokenSettings.issuer
+  }
+
+  return new Promise((resolve, reject) => {
+    jwt.verify(token, businessToken.secret, options, (err, payload) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(businessToken)
+      }
+    })
+  })
 }

--- a/api/src/coordinators/projectToken.test-u.js
+++ b/api/src/coordinators/projectToken.test-u.js
@@ -1,4 +1,5 @@
-import { createProjectToken } from './projectToken'
+import jsonwebtoken from 'jsonwebtoken'
+import { createProjectToken, verifyProjectToken } from './projectToken'
 import randomStringGenerator from '../libs/randomStringGenerator'
 import tokenGenerator from '../integrators/token'
 import BusinessProjectToken from '../businesstime/projecttoken'
@@ -8,6 +9,7 @@ import resourcePublicFields from '../constants/resourcePublicFields'
 jest.mock('../businesstime/projecttoken')
 jest.mock('../integrators/token')
 jest.mock('../libs/randomStringGenerator')
+jest.mock('jsonwebtoken')
 
 describe('projectToken coordinator', () => {
   const name = 'Project Token Name'
@@ -42,6 +44,42 @@ describe('projectToken coordinator', () => {
 
     it('should return a token', () => {
       expect(Object.keys(token)).toEqual(expect.arrayContaining(resourcePublicFields[resourceTypes.PROJECT_TOKEN]))
+    })
+  })
+
+  describe('#verifyProjectToken', () => {
+    let verifiedToken
+    const decodedToken = {
+      id: 123,
+      orgId: 456
+    }
+    const tokenString = 'this-token-is-fake'
+
+    beforeAll(async () => {
+      jsonwebtoken.decode.mockReturnValue(decodedToken)
+      jsonwebtoken.verify.mockImplementation((token, secret, options, callback) => {
+        callback(null, decodedToken)
+      })
+      verifiedToken = await verifyProjectToken(tokenString)
+    })
+
+    it('should return the token', () => {
+      expect(Object.keys(verifiedToken)).toEqual(expect.arrayContaining(['id', 'token', 'name']))
+    })
+
+    it('should find unsanitized token by id', () => {
+      expect(BusinessProjectToken.findByIdUnsanitized.mock.calls.length).toBe(1)
+      expect(BusinessProjectToken.findByIdUnsanitized.mock.calls[0][0]).toBe(decodedToken.id)
+    })
+
+    it('should decode jwt', () => {
+      expect(jsonwebtoken.decode.mock.calls.length).toBe(1)
+      expect(jsonwebtoken.decode.mock.calls[0][0]).toBe(tokenString)
+    })
+
+    it('should verify jwt', () => {
+      expect(jsonwebtoken.verify.mock.calls.length).toBe(1)
+      expect(jsonwebtoken.verify.mock.calls[0][0]).toBe(tokenString)
     })
   })
 })

--- a/api/src/libs/auth/auth.js
+++ b/api/src/libs/auth/auth.js
@@ -19,6 +19,7 @@ const init = (passport) => {
 
 export default {
   jwtMiddleware: passport.authenticate('jwt', { session: false }),
+  jwtProjectTokenMiddleware: passport.authenticate('dangerProjectToken', { session: false }),
   loginMiddleware: passport.authenticate('local', { session: false }),
   jwtPasswordResetMiddleware: passport.authenticate('jwt-password-reset', { session: false }),
   init

--- a/api/src/libs/auth/auth.js
+++ b/api/src/libs/auth/auth.js
@@ -1,5 +1,6 @@
 import passport from 'passport'
 import JWTAuth from './passportJWT'
+import JWTProjectToken from './projectTokenJWT'
 import localAuth from './passportLocal'
 import JWTPasswordResetAuth from './passportJWTPasswordReset'
 
@@ -13,13 +14,13 @@ const init = (passport) => {
   })
 
   JWTAuth(passport)
+  JWTProjectToken(passport)
   localAuth(passport)
   JWTPasswordResetAuth(passport)
 }
 
 export default {
-  jwtMiddleware: passport.authenticate('jwt', { session: false }),
-  jwtProjectTokenMiddleware: passport.authenticate('dangerProjectToken', { session: false }),
+  jwtMiddleware: passport.authenticate(['jwt', 'dangerProjectToken'], { session: false }),
   loginMiddleware: passport.authenticate('local', { session: false }),
   jwtPasswordResetMiddleware: passport.authenticate('jwt-password-reset', { session: false }),
   init

--- a/api/src/libs/auth/passportJWT.js
+++ b/api/src/libs/auth/passportJWT.js
@@ -1,5 +1,6 @@
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt'
-import tokenSettings from './tokenSettings'
+import tokenSettings from '../tokenSettings'
+import RESOURCE_TYPES from '../../constants/resourceTypes'
 
 const options = {
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -11,7 +12,13 @@ export default function(passport) {
   passport.use(
     new JwtStrategy(options, (payload, done) => {
       if (payload.userId) {
-        done(null, { id: payload.userId, orgId: payload.orgId, orgRoleId: payload.oRId })
+        const userData = {
+          id: payload.userId,
+          orgId: payload.orgId,
+          orgRoleId: payload.oRId,
+          type: RESOURCE_TYPES.USER
+        }
+        done(null, userData)
       } else {
         done(null, false)
       }

--- a/api/src/libs/auth/passportJWTPasswordReset.js
+++ b/api/src/libs/auth/passportJWTPasswordReset.js
@@ -1,8 +1,7 @@
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt'
 import ono from 'ono'
-
-import tokenSettings from './tokenSettings'
-import UserCoordinator from '../coordinators/user'
+import tokenSettings from '../tokenSettings'
+import UserCoordinator from '../../coordinators/user'
 
 const options = {
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),

--- a/api/src/libs/auth/passportLocal.js
+++ b/api/src/libs/auth/passportLocal.js
@@ -1,5 +1,5 @@
 import { Strategy as LocalStrategy } from 'passport-local'
-import UserCoordinator from '../coordinators/user'
+import UserCoordinator from '../../coordinators/user'
 import ono from 'ono'
 
 const options = {

--- a/api/src/libs/auth/projectTokenJWT.js
+++ b/api/src/libs/auth/projectTokenJWT.js
@@ -1,0 +1,21 @@
+import { Strategy } from './projectTokenJWTStrategy'
+import { verifyProjectToken } from '../../coordinators/projectToken'
+import { pick } from '../utils'
+import RESOURCE_TYPES from '../../constants/resourceTypes'
+
+export default function(passport) {
+  passport.use(
+    new Strategy(async (token, done) => {
+      let validatedBusinessToken
+      try {
+        validatedBusinessToken = await verifyProjectToken(token)
+      } catch (e) {
+        done(e)
+      }
+
+      const tokenData = pick(validatedBusinessToken, ['id', 'roleId', 'projectId', 'orgId'])
+      tokenData.type = RESOURCE_TYPES.PROJECT_TOKEN
+      done(null, tokenData)
+    })
+  )
+}

--- a/api/src/libs/auth/projectTokenJWTStrategy.js
+++ b/api/src/libs/auth/projectTokenJWTStrategy.js
@@ -44,7 +44,7 @@ const getTokenFromReq = ExtractJwt.fromAuthHeaderAsBearerToken()
  * @param {Function} verify
  * @api public
  */
-function Strategy(options, verify) {
+export function Strategy(options, verify) {
   if (typeof options === 'function') {
     verify = options
     options = {}
@@ -92,7 +92,7 @@ Strategy.prototype.authenticate = function(req, options) {
   }
 
   try {
-    this._verify(req, token, verified)
+    this._verify(token, verified)
   } catch (ex) {
     return self.error(ex)
   }
@@ -101,6 +101,4 @@ Strategy.prototype.authenticate = function(req, options) {
 /**
  * Expose `Strategy`.
  */
-exports = {
-  Strategy
-}
+export default Strategy

--- a/api/src/libs/auth/projectTokenJWTStrategy.js
+++ b/api/src/libs/auth/projectTokenJWTStrategy.js
@@ -5,44 +5,11 @@ import passport from 'passport-strategy'
 import util from 'util'
 import { ExtractJwt } from 'passport-jwt'
 
-// Why re-invent the wheel holmes?
+// Re-use the wheel, use passport-jwt's token header extractor
 const getTokenFromReq = ExtractJwt.fromAuthHeaderAsBearerToken()
 
 /**
- * `Strategy` constructor.
- *
- * The token authentication strategy authenticates requests based on the
- * credentials submitted through standard request headers or body.
- *
- * Applications must supply a `verify` callback which accepts
- * unique `token` credentials, and then calls the `done` callback supplying a
- * `user`, which should be set to `false` if the credentials are not valid.
- * If an exception occured, `err` should be set.
- *
- * Optionally, `options` can be used to change the fields in which the
- * credentials are found.
- *
- * Options:
- *
- *   - `tokenField`  field name where the token is found, defaults to 'token'
- *   - `tokenQuery`  query string name where the token is found, defaults to 'token'
- *   - `tokenParams`  params name where the token is found, defaults to 'token'
- *   - `tokenHeader`  header name where the token is found, defaults to 'token'
- *   - `passReqToCallback`  when `true`, `req` is the first argument to the verify callback (default: `false`)
- *
- * Examples:
- *
- *     passport.use(new UniqueTokenStrategy(
- *       function(token, done) {
- *         User.findOne({ token: token }, function (err, user) {
- *           done(err, user);
- *         });
- *       }
- *     ));
- *
- * @param {Object} options
- * @param {Function} verify
- * @api public
+ * `Strategy` constructor. Needs to be a named export
  */
 export function Strategy(options, verify) {
   if (typeof options === 'function') {
@@ -64,13 +31,6 @@ export function Strategy(options, verify) {
  */
 util.inherits(Strategy, passport.Strategy)
 
-/**
- * Authenticate request based on the contents of a form submission.
- *
- * @param {Object} req
- * @param {Object} options
- * @api protected
- */
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {}
   const self = this
@@ -99,6 +59,6 @@ Strategy.prototype.authenticate = function(req, options) {
 }
 
 /**
- * Expose `Strategy`.
+ * Expose `Strategy` as default export too, because passport
  */
 export default Strategy

--- a/api/src/libs/auth/projectTokenJWTStrategy.js
+++ b/api/src/libs/auth/projectTokenJWTStrategy.js
@@ -1,0 +1,106 @@
+/**
+ * Module dependencies.
+ */
+import passport from 'passport-strategy'
+import util from 'util'
+import { ExtractJwt } from 'passport-jwt'
+
+// Why re-invent the wheel holmes?
+const getTokenFromReq = ExtractJwt.fromAuthHeaderAsBearerToken()
+
+/**
+ * `Strategy` constructor.
+ *
+ * The token authentication strategy authenticates requests based on the
+ * credentials submitted through standard request headers or body.
+ *
+ * Applications must supply a `verify` callback which accepts
+ * unique `token` credentials, and then calls the `done` callback supplying a
+ * `user`, which should be set to `false` if the credentials are not valid.
+ * If an exception occured, `err` should be set.
+ *
+ * Optionally, `options` can be used to change the fields in which the
+ * credentials are found.
+ *
+ * Options:
+ *
+ *   - `tokenField`  field name where the token is found, defaults to 'token'
+ *   - `tokenQuery`  query string name where the token is found, defaults to 'token'
+ *   - `tokenParams`  params name where the token is found, defaults to 'token'
+ *   - `tokenHeader`  header name where the token is found, defaults to 'token'
+ *   - `passReqToCallback`  when `true`, `req` is the first argument to the verify callback (default: `false`)
+ *
+ * Examples:
+ *
+ *     passport.use(new UniqueTokenStrategy(
+ *       function(token, done) {
+ *         User.findOne({ token: token }, function (err, user) {
+ *           done(err, user);
+ *         });
+ *       }
+ *     ));
+ *
+ * @param {Object} options
+ * @param {Function} verify
+ * @api public
+ */
+function Strategy(options, verify) {
+  if (typeof options === 'function') {
+    verify = options
+    options = {}
+  }
+
+  if (!verify) {
+    throw new TypeError('Danger authentication strategy requires a verify function')
+  }
+
+  passport.Strategy.call(this)
+  this.name = 'dangerProjectToken'
+  this._verify = verify
+}
+
+/**
+ * Inherit from `passport.Strategy`.
+ */
+util.inherits(Strategy, passport.Strategy)
+
+/**
+ * Authenticate request based on the contents of a form submission.
+ *
+ * @param {Object} req
+ * @param {Object} options
+ * @api protected
+ */
+Strategy.prototype.authenticate = function(req, options) {
+  options = options || {}
+  const self = this
+
+  const token = getTokenFromReq(req)
+
+  if (!token) {
+    return self.pass()
+  }
+
+  function verified(err, user, info) {
+    if (err) {
+      return self.error(err)
+    }
+    if (!user) {
+      return self.fail(info)
+    }
+    self.success(user, info)
+  }
+
+  try {
+    this._verify(req, token, verified)
+  } catch (ex) {
+    return self.error(ex)
+  }
+}
+
+/**
+ * Expose `Strategy`.
+ */
+exports = {
+  Strategy
+}

--- a/api/src/libs/middleware/reqInfoExtractorMiddleware.js
+++ b/api/src/libs/middleware/reqInfoExtractorMiddleware.js
@@ -15,6 +15,7 @@ export default async (req, res, next) => {
     }
     case RESOURCE_TYPES.PROJECT_TOKEN: {
       req.requestorInfo.projectId = req.user.projectId
+      req.requestorInfo.roleId = req.user.roleId
     }
   }
 

--- a/api/src/libs/middleware/reqInfoExtractorMiddleware.js
+++ b/api/src/libs/middleware/reqInfoExtractorMiddleware.js
@@ -2,12 +2,21 @@ import RESOURCE_TYPES from '../../constants/resourceTypes'
 
 // Builds the requestorInfo object on request
 export default async (req, res, next) => {
-  // TODO: update to handle API tokens
   req.requestorInfo = {
     orgId: req.user.orgId,
-    requestorType: RESOURCE_TYPES.USER,
+    requestorType: req.user.type,
     requestorId: req.user.id,
-    orgRoleId: req.user.orgRoleId
   }
+
+  switch (req.user.type) {
+    case RESOURCE_TYPES.USER: {
+      req.requestorInfo.orgRoleId = req.user.orgRoleId
+      break
+    }
+    case RESOURCE_TYPES.PROJECT_TOKEN: {
+      req.requestorInfo.projectId = req.user.projectId
+    }
+  }
+
   next()
 }

--- a/api/src/libs/permissions/permissions.js
+++ b/api/src/libs/permissions/permissions.js
@@ -1,5 +1,5 @@
 import RESOURCE_TYPES, { PROJECT_RESOURCE_TYPES } from '../../constants/resourceTypes'
-import { ORGANIZATION_ROLES, PROJECT_ROLES, PROJECT_ROLE_IDS } from '../../constants/roles'
+import { ORGANIZATION_ROLES, PROJECT_ROLES } from '../../constants/roles'
 import checkRolePermissions from './checkRolePermissions'
 import projectPermissionGenerator from './projectPermissionGenerator'
 import resourceToProject from '../resourceToProject'
@@ -78,6 +78,7 @@ export async function getProjectRoles(requestorInfo, requestedAction) {
 }
 
 async function projectResourceHandler(requestorInfo, requestedAction) {
+  permissionsDebug(`projectResourceHandler entry`)
   const projectRoles = await getProjectRoles(requestorInfo, requestedAction)
   permissionsDebug(`project roles: ${JSON.stringify(projectRoles)}`)
   const hasProjectPermission = checkRolePermissions(

--- a/api/src/libs/permissions/permissions.test-i.js
+++ b/api/src/libs/permissions/permissions.test-i.js
@@ -122,5 +122,59 @@ describe('Permissions', () => {
         })
       })
     })
+
+    describe('project token requestor', () => {
+      let requestorInfo
+      beforeAll(() => {
+        requestorInfo = {
+          orgId: project.orgId,
+          requestorType: RESOURCE_TYPES.PROJECT_TOKEN,
+          requestorId: 1234,
+          roleId: PROJECT_ROLE_IDS.READER,
+          projectId: project.id
+        }
+      })
+
+      describe('requests a project resource', () => {
+        describe('with project access', () => {
+          let hasPermission
+
+          beforeAll(async () => {
+            const requestedAction = {
+              resourceType: RESOURCE_TYPES.PROJECT,
+              action: ACTIONS.READ,
+              data: {
+                id: project.id
+              }
+            }
+            hasPermission = await permissions(requestorInfo, requestedAction)
+          })
+
+          it('should return true', () => {
+            expect(hasPermission).toBe(true)
+          })
+        })
+        describe('for a different project', () => {
+          let hasPermission
+          beforeAll(async () => {
+            const anotherProject = (await ProjectFactory.createMany(1, {
+              orgId: project.orgId
+            }))[0]
+            const requestedAction = {
+              resourceType: RESOURCE_TYPES.PROJECT,
+              action: ACTIONS.READ,
+              data: {
+                id: anotherProject.id
+              }
+            }
+            hasPermission = await permissions(requestorInfo, requestedAction)
+          })
+
+          it('should return false', () => {
+            expect(hasPermission).toBe(false)
+          })
+        })
+      })
+    })
   })
 })

--- a/api/src/libs/permissions/permissions.test-i.js
+++ b/api/src/libs/permissions/permissions.test-i.js
@@ -7,6 +7,7 @@ import ACTIONS from '../../constants/actions'
 import initializeTestDb from '../../db/__testSetup__/initializeTestDb'
 import { getDb } from '../../db/dbConnector'
 import BusinessProjectUser from '../../businesstime/projectuser'
+import RESOURCE_TYPES from '../../constants/resourceTypes'
 
 describe('Permissions', () => {
   beforeAll(async () => {
@@ -20,7 +21,7 @@ describe('Permissions', () => {
       const user = (await UserFactory.createMany(1, { orgRoleId: ORGANIZATION_ROLE_IDS.ADMIN }))[0]
       requestorInfo = {
         orgId: user.orgId,
-        requestorType: 'user',
+        requestorType: RESOURCE_TYPES.USER,
         requestorId: user.id,
         orgRoleId: user.orgRoleId
       }

--- a/api/src/libs/permissions/permissions.test-u.js
+++ b/api/src/libs/permissions/permissions.test-u.js
@@ -1,12 +1,14 @@
 import { getOrganizationRole } from './permissions'
+import RESOURCE_TYPES from '../../constants/resourceTypes'
 
-describe('getOrganizationRole', () => {
+
+describe('#getOrganizationRole', () => {
   describe('with an orgRoleId', () => {
     let orgRoles
     beforeAll(() => {
       const requestorInfo = {
         requestorId: 1,
-        requestorType: 'user',
+        requestorType: RESOURCE_TYPES.USER,
         orgId: 1,
         orgRoleId: 1
       }


### PR DESCRIPTION
So you have a project token? And you want to use it to access project resources? Now you can!!!

- custom passport strategy to use project tokens
- code path in permissions is pretty quick to skip over orgs, and project user roles when using project tokens, so little overhead there
- The most overhead is having to run the jwt auth and fail before running the custom project token jwt auth. Might be a way to short-circuit that down the road