### PR TITLE
error consistency

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -801,13 +801,6 @@ components:
           description: Number value with maximum of 15 significant digits (including decimal digits).
             For longer numbers we recommend storing as a string and parsing the value in your code.
           example: 1234567890.12345
-    Error:
-      required:
-        - code
-        - message
-      properties:
-        error:
-          type: string
 
     ProjectUser:
       allOf:
@@ -840,3 +833,29 @@ components:
       properties:
         roleId:
           type: number
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        error:
+          type: string
+        errorType:
+          type: string
+          description: Optional error type
+          enum:
+            - undefined
+            - ValidationError
+            - FieldValueIncorrectTypeError
+        errorDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorDetail'
+
+    ErrorDetail:
+      properties:
+        message:
+          type: string
+        key:
+          type: string      

--- a/api/src/controllers/userProjectAssignments.js
+++ b/api/src/controllers/userProjectAssignments.js
@@ -4,6 +4,7 @@ import BusinessProjectUser from '../businesstime/projectuser'
 import RESOURCE_TYPES from '../constants/resourceTypes'
 import ACTIONS from '../constants/actions'
 import perms from '../libs/middleware/reqPermissionsMiddleware'
+import apiErrorTypes from '../constants/apiErrorTypes';
 
 const readPerm = (req, res, next) => {
   const { userId } = req.params
@@ -18,7 +19,7 @@ const readPerm = (req, res, next) => {
     })(req, res, next)
   }
 
-  res.status(403).send('Invalid Permissions')
+  res.status(403).send({ error: 'Invalid Permissions' })
 }
 
 const paramSchema = Joi.compile({

--- a/api/src/controllers/userProjects.js
+++ b/api/src/controllers/userProjects.js
@@ -18,7 +18,7 @@ const listPerm = (req, res, next) => {
     })(req, res, next)
   }
 
-  res.status(403).send('Invalid Permissions')
+  res.status(403).send({ error: 'Invalid Permissions' })
 }
 
 const paramSchema = Joi.compile({

--- a/api/src/libs/middleware/reqPermissionsMiddleware.js
+++ b/api/src/libs/middleware/reqPermissionsMiddleware.js
@@ -1,4 +1,6 @@
 import checkPermission from '../permissions/permissions'
+import RESOURCE_TYPES from '../../constants/resourceTypes'
+import apiErrorTypes from '../../constants/apiErrorTypes';
 /*
 requestorInfo = {
   orgId: '123',
@@ -47,7 +49,7 @@ export default (actionBuilder) => {
         throw new Error('Invalid Permissions')
       }
     } catch (e) {
-      res.status(403).send('Invalid Permissions')
+      res.status(403).send({ error: 'Invalid Permissions' })
     }
   }
 }

--- a/api/src/libs/middleware/reqPermissionsMiddleware.js
+++ b/api/src/libs/middleware/reqPermissionsMiddleware.js
@@ -1,6 +1,4 @@
 import checkPermission from '../permissions/permissions'
-import RESOURCE_TYPES from '../../constants/resourceTypes'
-import apiErrorTypes from '../../constants/apiErrorTypes';
 /*
 requestorInfo = {
   orgId: '123',


### PR DESCRIPTION
- gets 403s in line with other error types
- started to add a ProjectPermissionError type, but realized all permissions are passthrough Organization check -> Project check so there's not a good way to differentiate these since the response will always be sent in the Project check
- updated docs with full error format