### PR TITLE
UI – Adds loading state adjustment for project creation

### DIFF
--- a/web/src/client/js/components/Permission/ProjectPermission.js
+++ b/web/src/client/js/components/Permission/ProjectPermission.js
@@ -31,7 +31,7 @@ const ProjectPermission = ({ children, elseRender, acceptedRoleIds, projectId })
   const projectAssignment = userProjectAssignments[Number(projectId)]
 
   // Check the manual project role assignments for the current user
-  if (acceptedRoleIds.includes(projectAssignment.roleId)) {
+  if (projectAssignment && acceptedRoleIds.includes(projectAssignment.roleId)) {
     return successRender
   }
 

--- a/web/src/client/js/reducers/projects.js
+++ b/web/src/client/js/reducers/projects.js
@@ -45,10 +45,13 @@ export const projects = (state = initialState, action) => {
       const loadingById = { ...state.loading.byId, [id]: false }
       return { ...state, loading: { ...state.loading, byId: loadingById } }
     }
+    case ActionTypes.CREATE_PROJECT: {
+      return { ...state, loading: { ...state.loading, list: true } }
+    }
     case ActionTypes.RECEIVE_CREATED_PROJECT: {
       const id = action.data.id
       const projectsById = { ...state.projectsById, [id]: action.data }
-      return { ...state, projectsById }
+      return { ...state, projectsById, loading: { ...state.loading, list: false } }
     }
     case ActionTypes.INITIATE_PROJECT_UPDATE: {
       const id = action.id


### PR DESCRIPTION
* Adjusts list loading state when creating project

**Note**: Had to add a check for `projectAssignment` in ProjectPermission component or it would error out with projectAssignment being undefined. Not sure if this is why you can create a project, go to that project, but the ProjectPermission component is still hiding the Settings link from you until you do a hard refresh. 