### PR TITLE
process string values for number field type

### DIFF
--- a/api/src/businesstime/field.js
+++ b/api/src/businesstime/field.js
@@ -257,7 +257,7 @@ function validateFieldValueByType(fieldValue, type) {
     throw ono({ code: 400, message, errorType: apiErrorTypes.FieldValueIncorrectTypeError }, message)
   }
 }
-// Goherenext
+
 function validateNumberValue(value) {
   value = BigNumber(value)
   if (Number.isNaN(value.toNumber())) {

--- a/api/src/businesstime/field.test-i.js
+++ b/api/src/businesstime/field.test-i.js
@@ -219,21 +219,42 @@ describe('BusinessField', () => {
       })
 
       describe('and the value is a string', () => {
-        let updatedField
-        const updateNumber = "273.45"
-        const expectedReturnValue = 273.45
 
-        beforeAll(async () => {
-          updatedField = await BusinessField.updateByIdForDocument(numberField.id, updateFactoryDocument.id, updateFactoryDocument.orgId, { value: updateNumber })
+        describe('that is valid', () => {
+          let updatedField
+          const updateNumber = "273.45"
+          const expectedReturnValue = 273.45
+  
+          beforeAll(async () => {
+            updatedField = await BusinessField.updateByIdForDocument(numberField.id, updateFactoryDocument.id, updateFactoryDocument.orgId, { value: updateNumber })
+          })
+  
+          it('should return a number value', () => {
+            expect(typeof updatedField.value).toBe('number')
+          })
+  
+          it('should update the number', () => {
+            expect(updatedField.value).toBe(expectedReturnValue)
+          })   
         })
-
-        it('should return a number value', () => {
-          expect(typeof updatedField.value).toBe('number')
+        
+        describe('that is invalid', () => {
+          it('should throw an error', async () => {
+            await expect(
+              BusinessField.updateByIdForDocument(
+                numberField.id, 
+                updateFactoryDocument.id, 
+                updateFactoryDocument.orgId, 
+                {
+                  value: 'not a number'
+                }
+              )              
+            ).rejects.toEqual(expect.objectContaining({ 
+              code: 400, 
+              errorType: apiErrorTypes.ValidationError 
+            }))
+          })
         })
-
-        it('should update the number', () => {
-          expect(updatedField.value).toBe(expectedReturnValue)
-        })        
       })
     })
 


### PR DESCRIPTION
Numbers are hard.

This update allows the API to accept string values for numbers, assuming the string can parse to a valid number. If the string cannot be parsed, the API returns an error.

Problems I didn't solve:
- Keeping significant digits. I don't think this solution is any better, it was supposed to handle significant digits (eg input "123.00" and you'd get a return value of type number 123.00). Except javascript doesn't do that, and the BigNumber conversion doesn't track the significant digits, significant digits have to be set on the constructor. And there's no easy way to determine significant digits from input string values (string length doesn't work)

Soooo, I don't know that we even want this code.

