### PR TITLE
early error if no user deserialized from auth token

### DIFF
--- a/api/src/libs/middleware/reqInfoExtractorMiddleware.js
+++ b/api/src/libs/middleware/reqInfoExtractorMiddleware.js
@@ -1,7 +1,12 @@
 import RESOURCE_TYPES from '../../constants/resourceTypes'
+import ono from 'ono';
 
 // Builds the requestorInfo object on request
 export default async (req, res, next) => {
+  if (!req.user) {
+    return next(ono({ code: 404 }, 'The auth token did not contain valid data'))
+  }
+
   req.requestorInfo = {
     orgId: req.user.orgId,
     requestorType: req.user.type,


### PR DESCRIPTION
The server was hanging if there was no auth token in the header. This makes sure the auth token contains a valid user before assembling requestor info.

@dheniges Not 100% sure this is where the check should happen, but seemed like we'd need to repeat the logic if we tried to do it in the user / api token auth modules