### PR TITLE
Fixing fullscreen cross-browser

### DIFF
--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -19,7 +19,6 @@ const DocumentComponent = ({
   removeDocumentHandler,
   toggleFullScreenHandler,
 }) => {
-  const documentRef = useRef()
   const titleRef = useRef()
 
   // If we've exited fullscreen, but the UI is still in fullscreen
@@ -47,7 +46,7 @@ const DocumentComponent = ({
     nameChangeHandler(e)
   })
   return (
-    <div className="document" key={docKey} ref={documentRef}>
+    <div className="document" key={docKey}>
       <ValidationContainer resource="document" value="name" />
       <header className="document__header">
         <button

--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 
 import { debounce } from 'Shared/utilities'
@@ -12,13 +12,32 @@ import './_Document.scss'
 
 const DocumentComponent = ({
   document,
+  isFullScreen,
   isPublishing,
   nameChangeHandler,
   publishDocumentHandler,
   removeDocumentHandler,
   toggleFullScreenHandler,
 }) => {
+  const documentRef = useRef()
   const titleRef = useRef()
+
+  // If we've exited fullscreen, but the UI is still in fullscreen
+  // This happens when hitting the escape key when in fullscreen
+  useEffect(() => {
+    function fullScreenChangeHandler(e) {
+      const fullscreenElement = window.document.fullscreenElement || window.document.webkitCurrentFullScreenElement
+      if (!fullscreenElement && isFullScreen) toggleFullScreenHandler()
+      return
+    }
+    window.document.addEventListener('fullscreenchange', fullScreenChangeHandler, false)
+    window.document.addEventListener('webkitfullscreenchange', fullScreenChangeHandler, false)
+    return function cleanup() {
+      window.document.removeEventListener('fullscreenchange', fullScreenChangeHandler, false)
+      window.document.removeEventListener('webkitfullscreenchange', fullScreenChangeHandler, false)
+    }
+  })
+
   const docKey = document ? document.id : 0
   const dropdownButton = {
     className: 'btn btn--blank btn--with-circular-icon',
@@ -28,12 +47,24 @@ const DocumentComponent = ({
     nameChangeHandler(e)
   })
   return (
-    <div className="document" key={docKey}>
+    <div className="document" key={docKey} ref={documentRef}>
       <ValidationContainer resource="document" value="name" />
       <header className="document__header">
         <button
           className="btn btn--blank document__button-expand"
-          onClick={toggleFullScreenHandler}
+          onClick={() => {
+            // This has to be here because of Safari
+            // You have to call fullscreen functions on the actual element onClick
+            if (window.document.fullscreenElement || window.document.webkitFullscreenElement) {
+              const exitFullscreen = window.document.exitFullscreen || window.document.webkitExitFullscreen
+              exitFullscreen.call(window.document)
+            } else {
+              const documentEl = window.document.documentElement
+              const requestFullscreen = documentEl.webkitRequestFullscreen || documentEl.requestFullscreen
+              requestFullscreen.call(documentEl)
+            }
+            toggleFullScreenHandler()
+          }}
           title="Expand to full screen">
           <ExpandIcon />
         </button>
@@ -75,6 +106,7 @@ const DocumentComponent = ({
 // @todo fill out this document object and add defaults
 DocumentComponent.propTypes = {
   document: PropTypes.object,
+  isFullScreen: PropTypes.bool.isRequired,
   isPublishing: PropTypes.bool.isRequired,
   nameChangeHandler: PropTypes.func.isRequired,
   publishDocumentHandler: PropTypes.func.isRequired,

--- a/web/src/client/js/components/Document/DocumentContainer.js
+++ b/web/src/client/js/components/Document/DocumentContainer.js
@@ -71,7 +71,7 @@ const DocumentContainer = ({
     const confirmedAction = () => { deleteDocument(document.projectId, document.id, history) }
     uiConfirm({ message, confirmedAction, confirmedLabel })
   }
-  function toggleFullScreenHandler() {
+  function toggleFullScreenHandler(e) {
     uiToggleFullScreen(!isFullScreen)
   }
 
@@ -83,6 +83,7 @@ const DocumentContainer = ({
 
       <DocumentComponent
         document={document}
+        isFullScreen={isFullScreen}
         isPublishing={documents.isPublishing}
         nameChangeHandler={nameChangeHandler}
         publishDocumentHandler={publishDocumentHandler}

--- a/web/src/client/js/reducers/ui.js
+++ b/web/src/client/js/reducers/ui.js
@@ -99,15 +99,6 @@ export const ui = (state = initialState, action) => {
     // Document full screen
     // -------------------------------------------------------------------------
     case ActionTypes.UI_DOCUMENT_FULL_SCREEN: {
-      if (action.value) {
-        if (!document.fullscreenElement) {
-          document.documentElement.requestFullscreen()
-        }
-      } else {
-        if (document.exitFullscreen) {
-          document.exitFullscreen()
-        }
-      }
       return {
         ...state,
         document: {


### PR DESCRIPTION
Fixes fullscreen for Safari, should be able to fullscreen a document in all the browsers. Make sure UI expands back when exiting fullscreen using escape key or the button