### PR TITLE
Remove webpack API url build arg dependency

### DIFF
--- a/docs/do-kubernetes-setup.md
+++ b/docs/do-kubernetes-setup.md
@@ -152,5 +152,5 @@ docker-compose run --no-deps api ./run.sh start
 
 Web build for dev environment:
 ```
-docker build --build-arg API_PUBLIC_URL=https://api.dev.portway.app -t bonkeybong/portway_web:dev2 -f web/Dockerfile-prod web/
+docker build -t bonkeybong/portway_web:dev2 -f web/Dockerfile-prod web/
 ```

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -32,8 +32,6 @@ steps:
     working_directory: ./web/
     tag: '${{CF_RELEASE_TAG}}'
     dockerfile: Dockerfile-prod
-    build_arguments:
-      - API_PUBLIC_URL=https://api.dev.portway.app
     when:
       steps:
         - name: main_clone

--- a/web/Dockerfile-prod
+++ b/web/Dockerfile-prod
@@ -3,10 +3,6 @@ FROM node:10.15.1-alpine
 # The base node image sets a very verbose log level.
 ENV NPM_CONFIG_LOGLEVEL warn
 
-ARG API_PUBLIC_URL
-
-ENV API_PUBLIC_URL=${API_PUBLIC_URL}
-
 WORKDIR /web
 
 # Only copy package.json first to take advantage of docker caching

--- a/web/config/webpack.shared.js
+++ b/web/config/webpack.shared.js
@@ -43,9 +43,6 @@ const SharedConfig = {
       },
       minify: true,
       staticFileGlobsIgnorePatterns: [/\.map$/, /manifest\.json$/]
-    }),
-    new webpack.DefinePlugin({
-      VAR_API_URL: JSON.stringify(process.env.API_PUBLIC_URL)
     })
   ],
   optimization: {

--- a/web/run.sh
+++ b/web/run.sh
@@ -12,7 +12,7 @@ case $1 in
     npm run serve
     ;;
   local)
-    API_PUBLIC_URL=http://localhost:3001 npm run build && API_URL=http://localhost:3001 JWT_SECRET=jwtauthsecret NODE_ENV=production node dist/server/app.js
+    npm run build && API_PUBLIC_URL=http://localhost:3001 API_URL=http://localhost:3001 JWT_SECRET=jwtauthsecret NODE_ENV=production node dist/server/app.js
     ;;
   install)
     npm install

--- a/web/src/client/js/api/index.js
+++ b/web/src/client/js/api/index.js
@@ -3,10 +3,11 @@ import { getCookieValue } from '../utilities/cookieParser'
 
 const token = getCookieValue('token')
 
-// Webpack's DefinePlugin sets VAR_API_URL during build from
-// process.env.API_PUBLIC_URL
+// Express renders the app html page and sets API_PUBLIC_URL in order to keep
+// this webpack bundle API-location agnostic. To set the API url, the node.js
+// express server needs process.env.API_PUBLIC_URL set
 // eslint-disable-next-line no-undef
-const baseURL = new URL('api/', VAR_API_URL)
+const baseURL = new URL('api/', API_PUBLIC_URL)
 const globalErrorCodes = [403, 404, 408, 500, 503]
 const validationCodes = [400, 402, 409, 413, 415]
 

--- a/web/src/server/controllers/app.js
+++ b/web/src/server/controllers/app.js
@@ -2,8 +2,9 @@ import { renderBundles } from '../libs/express-utilities'
 
 const AppController = function(router) {
   // Sending all requests to dashboard view, for Redux Router
-  router.get('*', (req, res, next) => {
-    res.render('app/index', renderBundles(req, 'Welcome', 'app'))
+  router.get('*', (req, res) => {
+    const bundleTemplateVars = renderBundles(req, 'Welcome', 'app')
+    res.render('app/index', { ...bundleTemplateVars, apiPublicUrl: process.env.API_PUBLIC_URL } )
   })
 }
 

--- a/web/src/server/libs/express-utilities.js
+++ b/web/src/server/libs/express-utilities.js
@@ -1,6 +1,5 @@
 import { makePermalinkWithString } from '../libs/string-utilities'
 import constants from '../../shared/constants'
-const apiUrl = process.env.API_URL
 
 export const renderBundles = (req, pageTitle, bundleKey) => {
   let flash
@@ -27,8 +26,7 @@ export const renderBundles = (req, pageTitle, bundleKey) => {
     flash: flash,
     permalink: makePermalinkWithString(pageTitle),
     css: bundleKey ? req.app.locals.bundles[bundleKey].css : undefined,
-    js: bundleKey ? req.app.locals.bundles[bundleKey].js : undefined,
-    apiUrl: apiUrl
+    js: bundleKey ? req.app.locals.bundles[bundleKey].js : undefined
   }
 }
 

--- a/web/src/server/views/app/index.ejs
+++ b/web/src/server/views/app/index.ejs
@@ -1,4 +1,7 @@
 <%- include('../partials/head', { title: title, permalink: permalink, robots: 'noindex, nofollow' }); %>
+<script type="text/javascript">
+  const API_PUBLIC_URL = "<%= apiPublicUrl %>";
+</script>
 <div id="application" role="application">
   <!-- Overwrittem by js/app.js -->
   <div>

--- a/web/src/server/views/app/index.ejs
+++ b/web/src/server/views/app/index.ejs
@@ -1,7 +1,4 @@
 <%- include('../partials/head', { title: title, permalink: permalink, robots: 'noindex, nofollow' }); %>
-<script type="text/javascript">
-  const API_PUBLIC_URL = "<%= apiPublicUrl %>";
-</script>
 <div id="application" role="application">
   <!-- Overwrittem by js/app.js -->
   <div>
@@ -37,6 +34,9 @@
   </div>
   <!-- Overwrittem by js/app.js -->
 </div>
+<script type="text/javascript">
+  const API_PUBLIC_URL = "<%= apiPublicUrl %>";
+</script>
 <%- include('../partials/foot'); %>
 
 


### PR DESCRIPTION
Why have a build arg when you can party with ejs?

This allows us to create a release that's deployable on any environment.