### PR TITLE
Fixing notification styles

### DIFF
--- a/web/src/client/js/components/Notifications/NotificationComponent.js
+++ b/web/src/client/js/components/Notifications/NotificationComponent.js
@@ -6,6 +6,8 @@ import { NOTIFICATION_TYPES } from 'Shared/constants'
 import { RemoveIcon } from 'Components/Icons'
 import { getNotificationTitle, getNotificationMessage } from './NotificationMessages'
 
+import './_Notifications.scss'
+
 const NotificationComponent = ({ dismissHandler, id, notification }) => {
   const notificationClasses = cx({
     'notifications__notification': true,

--- a/web/src/client/js/components/Notifications/NotificationsContainer.js
+++ b/web/src/client/js/components/Notifications/NotificationsContainer.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 
 import { dismissNotification } from 'Actions/notifications'
 import NotificationList from './NotificationList'
-import './Notifications.scss'
 
 const NotificationsContainer = ({ dismissNotification, notifications }) => {
   const notificationArray = Object.keys(notifications).map((key) => {

--- a/web/src/client/js/components/Notifications/_Notifications.scss
+++ b/web/src/client/js/components/Notifications/_Notifications.scss
@@ -22,10 +22,7 @@
 .notifications {
   --notification-width: 300px;
   --notification-space: calc(var(--brand-width) / 2);
-  --notification-background: var(--color-gray-60);
-  @media (prefers-color-scheme: dark) {
-    --notification-background: var(--color-gray-80);
-  }
+  --notification-background: var(--theme-overlay-dark);
   display: block;
   position: fixed;
   left: 100vw;
@@ -71,6 +68,9 @@
 
   &__remove {
     margin-right: 1rem;
+    .icon {
+      background-color: var(--theme-overlay-light);
+    }
   }
 
 }


### PR DESCRIPTION
Fixes notification styling. To test, paste this in the "Dispatcher" section of Redux Tools:

```
{
type: 'CREATE_NOTIFICATION',
message: "This won't show up because its a 403",
noticeType: "error",
resource: "DOCUMENT",
code: 403
}
```

or

```
{
type: 'CREATE_NOTIFICATION',
message: "Hoooooraaaaay",
noticeType: "success",
resource: "DOCUMENT",
code: 200
}
```