### PR TITLE
Reconfigure controller middleware loading

### DIFF
--- a/api/src/controllers/loader.js
+++ b/api/src/controllers/loader.js
@@ -68,18 +68,18 @@ const loadControllers = (router, controllers, middleware = [], routerOptions) =>
     const controllerRouter = express.Router(routerOptions)
     controller(controllerRouter)
 
-    let expandedMiddleware
-    // activate body parsing middleware for each route, default to json parsing, unless otherwise specified
+    const expandedMiddleware = [...middleware]
+    // activate body parsing middleware for each route, before other middleware.
+    // Default to json parsing, unless otherwise specified
     if (controllers[path].customBodyParsingMiddleware) {
-      expandedMiddleware = [...middleware, controllers[path].customBodyParsingMiddleware]
+      expandedMiddleware.unshift(controllers[path].customBodyParsingMiddleware)
     } else {
-      expandedMiddleware = [...middleware, bodyParser.json()]
+      expandedMiddleware.unshift(bodyParser.json())
     }
-    // activate subscription status check middleware for each route, default is to only allow active orgs access
-    // unless allowInactiveOrgAccess is set to true
-
+    // activate subscription status check middleware for each route, default is to only allow active
+    // orgs access unless allowInactiveOrgAccess is set to true
     if (!controllers[path].allowInactiveOrgAccess) {
-      expandedMiddleware = [...middleware, checkActiveOrgStatus]
+      expandedMiddleware.push(checkActiveOrgStatus)
     }
 
     router.use(path, ...expandedMiddleware, controllerRouter)


### PR DESCRIPTION
- Ensure body parsing happens first
- Makes sure various options for each controller don't override each other (modify the same middleware array rather than replacing)