### PR TITLE
fixing bad logic in JWT project token auth

### DIFF
--- a/api/src/businesstime/organization.js
+++ b/api/src/businesstime/organization.js
@@ -41,6 +41,10 @@ async function findById(orgId) {
   const db = getDb()
   const organization = await db.model(MODEL_NAME).findByPk(orgId)
 
+  if (!organization) {
+    throw ono({ code: 404 }, `Cannot find organization with id: ${orgId}`)
+  }
+
   return organization.get({ plain: true })
 }
 

--- a/api/src/businesstime/organization.test-i.js
+++ b/api/src/businesstime/organization.test-i.js
@@ -68,17 +68,26 @@ describe('OrganizationBusiness', () => {
     })
 
     describe('#findById', () => {
-      let targetOrganizationId
-      let organization
+      describe('with a valid id', () => {
+        let targetOrganizationId
+        let organization
 
-      beforeAll(async () => {
-        targetOrganizationId = factoryOrganizations[0].get('id')
-        organization = await OrganizationBusiness.findById(targetOrganizationId)
+        beforeAll(async () => {
+          targetOrganizationId = factoryOrganizations[0].get('id')
+          organization = await OrganizationBusiness.findById(targetOrganizationId)
+        })
+
+        it('should return organization as POJO', () => {
+          expect(organization.id).toBe(targetOrganizationId)
+          expect(organization.constructor).toBe(Object)
+        })
       })
 
-      it('should return organization as POJO', () => {
-        expect(organization.id).toBe(targetOrganizationId)
-        expect(organization.constructor).toBe(Object)
+      it('with an invalid id should throw an error', async () => {
+        const targetOrgId = 'this aint no id'
+
+        await expect(OrganizationBusiness.findById(targetOrgId)).rejects
+          .toThrow(/Cannot find organization with id/)
       })
     })
   })

--- a/api/src/businesstime/organization.test-i.js
+++ b/api/src/businesstime/organization.test-i.js
@@ -84,7 +84,7 @@ describe('OrganizationBusiness', () => {
       })
 
       it('with an invalid id should throw an error', async () => {
-        const targetOrgId = 'this aint no id'
+        const targetOrgId = 124212421242
 
         await expect(OrganizationBusiness.findById(targetOrgId)).rejects
           .toThrow(/Cannot find organization with id/)

--- a/api/src/libs/auth/projectTokenJWT.js
+++ b/api/src/libs/auth/projectTokenJWT.js
@@ -10,7 +10,9 @@ export default function(passport) {
       try {
         validatedBusinessToken = await verifyProjectToken(token)
       } catch (e) {
-        done(e)
+        // TODO: do we want to log this? It's not an error, it's a 404
+        console.warn(e)
+        return done(null, false)
       }
 
       const tokenData = pick(validatedBusinessToken, ['id', 'roleId', 'projectId', 'orgId'])

--- a/api/src/libs/middleware/reqInfoExtractorMiddleware.js
+++ b/api/src/libs/middleware/reqInfoExtractorMiddleware.js
@@ -1,5 +1,5 @@
 import RESOURCE_TYPES from '../../constants/resourceTypes'
-import ono from 'ono';
+import ono from 'ono'
 
 // Builds the requestorInfo object on request
 export default async (req, res, next) => {


### PR DESCRIPTION
- Bonus: adds explicit 404 error to `organization.findById`
- Bugs in the JWT project token auth would not throw appropriate errors and would return a valid "token" with no orgId, id, etc. Fixed code + new tests ensure this is no longer the case