### PR TITLE
Title length and document mode cleanup

### DIFF
--- a/web/src/client/css/inc/_buttons.scss
+++ b/web/src/client/css/inc/_buttons.scss
@@ -241,8 +241,10 @@ button,
   &--warning {
     color: var(--color-orange);
     @media (hover: hover) {
-      &:hover {
-        color: var(--color-orange-dark);
+      &:not([disabled]) {
+        &:hover {
+          color: var(--color-orange-dark);
+        }
       }
     }
   }
@@ -250,8 +252,10 @@ button,
   &--danger {
     color: var(--color-red);
     @media (hover: hover) {
-      &:hover {
-        color: var(--color-red-dark);
+      &:not([disabled]) {
+        &:hover {
+          color: var(--color-red-dark);
+        }
       }
     }
   }

--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -63,7 +63,7 @@ const DocumentComponent = ({
           <ExpandIcon />
         </button>
         <div className="document__title-container">
-          <textarea
+          <input
             className="document__title"
             defaultValue={document.name}
             onChange={(e) => {

--- a/web/src/client/js/components/Document/_Document.scss
+++ b/web/src/client/js/components/Document/_Document.scss
@@ -55,7 +55,10 @@
     line-height: 3rem;
     padding: 0;
     outline: none;
+    overflow: hidden;
     resize: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     width: 100%;
     -webkit-appearance: none;
 

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import Constants from 'Shared/constants'
+import { FIELD_TYPES } from 'Shared/constants'
 import DocumentFieldComponent from './DocumentFieldComponent'
 import FieldTextComponent from 'Components/FieldText/FieldTextComponent'
 import FieldNumberComponent from 'Components/FieldNumber/FieldNumberComponent'
@@ -30,7 +30,7 @@ const DocumentFieldsComponent = ({
   const [settingsForField, setSettingsForField] = useState(null)
 
   const textFields = fields.filter((field) => {
-    return field.type === Constants.FIELD_TYPES.TEXT
+    return field.type === FIELD_TYPES.TEXT
   })
   const lastTextFieldId = textFields.length > 0 ? textFields[textFields.length - 1].id : null
 
@@ -45,7 +45,7 @@ const DocumentFieldsComponent = ({
   function renderFieldType(field, index) {
     let fieldTypeComponent
     switch (field.type) {
-      case Constants.FIELD_TYPES.TEXT:
+      case FIELD_TYPES.TEXT:
         fieldTypeComponent = (
           <FieldTextComponent
             autoFocusElement={lastTextFieldId}
@@ -56,7 +56,7 @@ const DocumentFieldsComponent = ({
           />
         )
         break
-      case Constants.FIELD_TYPES.NUMBER:
+      case FIELD_TYPES.NUMBER:
         fieldTypeComponent = (
           <FieldNumberComponent
             field={field}
@@ -66,7 +66,7 @@ const DocumentFieldsComponent = ({
           />
         )
         break
-      case Constants.FIELD_TYPES.STRING:
+      case FIELD_TYPES.STRING:
         fieldTypeComponent = (
           <FieldStringComponent
             field={field}
@@ -76,7 +76,7 @@ const DocumentFieldsComponent = ({
           />
         )
         break
-      case Constants.FIELD_TYPES.IMAGE:
+      case FIELD_TYPES.IMAGE:
         fieldTypeComponent = (
           <FieldImageComponent
             field={field}

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { withRouter } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
 
 import { debounce, isAnyPartOfElementInViewport } from 'Shared/utilities'
@@ -19,7 +19,6 @@ const DocumentFieldsContainer = ({
   fieldsUpdating,
   focusField,
   isPublishing,
-  match,
   removeField,
   uiConfirm,
   updateField,
@@ -27,8 +26,9 @@ const DocumentFieldsContainer = ({
 }) => {
   const [orderedFields, setOrderedFields] = useState([])
   const [draggingElement, setDraggingElement] = useState(null)
-  const { projectId, documentId } = match.params
-  const { data: fields = {} } = useDataService(dataMapper.fields.list(match.params.documentId), [match.params.documentId])
+  const params = useParams()
+  const { projectId, documentId } = params
+  const { data: fields = {} } = useDataService(dataMapper.fields.list(documentId), [documentId])
 
   let cloneElement
 
@@ -184,7 +184,6 @@ DocumentFieldsContainer.propTypes = {
   fieldsUpdating: PropTypes.object.isRequired,
   focusField: PropTypes.func.isRequired,
   isPublishing: PropTypes.bool.isRequired,
-  match: PropTypes.object.isRequired,
   removeField: PropTypes.func.isRequired,
   uiConfirm: PropTypes.func.isRequired,
   updateField: PropTypes.func.isRequired,
@@ -210,6 +209,4 @@ const mapDispatchToProps = {
   uiConfirm
 }
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(DocumentFieldsContainer)
-)
+export default connect(mapStateToProps, mapDispatchToProps)(DocumentFieldsContainer)

--- a/web/src/client/js/components/FieldText/FieldTextComponent.js
+++ b/web/src/client/js/components/FieldText/FieldTextComponent.js
@@ -37,7 +37,7 @@ const FieldTextComponent = ({ autoFocusElement, field, onBlur, onChange, onFocus
   }, [])
   useEffect(() => {
     if (editor) {
-      // editor.codemirror.on('blur', (cm, e) => { onBlur(field.id, field.type, cm) })
+      editor.codemirror.on('blur', (cm, e) => { onBlur(field.id, field.type, editor) })
       editor.codemirror.on('change', () => { onChange(field.id, editor.value()) })
       editor.codemirror.on('dragstart', (cm, e) => { e.preventDefault() })
       editor.codemirror.on('dragenter', (cm, e) => { e.preventDefault() })

--- a/web/src/client/js/reducers/documentFields.js
+++ b/web/src/client/js/reducers/documentFields.js
@@ -117,13 +117,9 @@ export const documentFields = (state = initialState, action) => {
       return { ...state, documentFieldsById, lastCreatedFieldId, loading: { ...state.loading, byId: loadingById } }
     }
     // Blur field resets focus data
-    case ActionTypes.BLUR_FIELD: {
-      const focused = { ...state.focused }
-      focused.id = null
-      focused.type = null
-      focused.data = null
-      return { ...state, focused }
-    }
+    // case ActionTypes.BLUR_FIELD: {
+    //   @todo Do whatever in here for multiple user stuff
+    // }
     // Focus field tracks field ID and certain data per type of field
     // This is so we can interact with the actual field component or ref from
     // somewhere else within the app

--- a/web/src/client/js/reducers/ui.js
+++ b/web/src/client/js/reducers/ui.js
@@ -131,6 +131,15 @@ export const ui = (state = initialState, action) => {
         }
       }
     }
+    case ActionTypes.ROUTE_CHANGE: {
+      return {
+        ...state,
+        document: {
+          ...state.document,
+          documentMode: initialState.document.documentMode,
+        }
+      }
+    }
 
     // Document full screen
     // -------------------------------------------------------------------------


### PR DESCRIPTION
* Adds ellipses overflow to long document names (make a really long document title, resize window)
* Takes the user out of document edit mode when switching routes