### PR TITLE
stop executing passport callback in err condition

### DIFF
--- a/api/src/libs/auth/passportLocal.js
+++ b/api/src/libs/auth/passportLocal.js
@@ -15,7 +15,7 @@ export default function(passport) {
       try {
         user = await UserCoordinator.validateEmailPasswordCombo(email, password)
       } catch (err) {
-        done(ono(err, `Invalid user/pass ${email}`))
+        return done(ono(err, `Invalid user/pass ${email}`))
       }
 
       console.info('logging in ' + email)


### PR DESCRIPTION
Without this change, an uncaught exception would be thrown because express was trying to send a second response from apiErrorHandler and the login route. Now this correctly stops executing the login route and passes the error along the middleware chain so only apiErrorHandler responds