### PR TITLE
Updates for taking prod live

### DIFF
--- a/kubernetes/helm/portway/prodValues.yaml
+++ b/kubernetes/helm/portway/prodValues.yaml
@@ -2,26 +2,27 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Lets Encrypt cert issuer
 certIssuer: letsencrypt-prod
 
-baseUrl: dev.portway.app
-apiPublicUrl: api.dev.portway.app
+baseUrl: portway.app
+apiPublicUrl: api.portway.app
 apiPort: "3001"
 stripePublishableKey: "pk_test_1pwhBFZzMbjvUlsgn2EjsfWP"
 
 apiImage: bonkeybong/portway_api
-apiTag: dev4
+apiTag: "0.9.1"
 
 webImage: bonkeybong/portway_web
-webTag: dev2
+webTag: "0.9.1"
 
 api:
-  cdnHostname: 'https://dev.portwaycontent.com'
+  cdnHostname: 'https://portwaycontent.com'
   s3ContentBucket: 'portway-content-dev'
   logger: 'r7insight'
 
 db:
-  host: "dev-db-portway-do-user-2269753-0.db.ondigitalocean.com"
+  host: "db-postgresql-sfo2-43619-do-user-2269753-0.db.ondigitalocean.com"
   port: "25060"
   user: "doadmin"
   name: "defaultdb"

--- a/kubernetes/helm/portway/templates/ingress.yaml
+++ b/kubernetes/helm/portway/templates/ingress.yaml
@@ -3,14 +3,15 @@ kind: Ingress
 metadata:
   name: portway-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: {{ .Values.certName }}
+    kubernetes.io/ingress.class: "nginx"
+    # This metadata controls which letsencrypt provider, staging or prod
+    cert-manager.io/issuer: {{ .Values.certIssuer }}
 spec:
   tls:
   - hosts:
     - {{ .Values.baseUrl }}
     - {{ .Values.apiPublicUrl }}
-    secretName: {{ .Values.certName }}
+    secretName: {{ .Values.certIssuer }}-cert
   rules:
   - host: {{ .Values.apiPublicUrl }}
     http:

--- a/kubernetes/letsencrypt/letsencrypt-prod.yaml
+++ b/kubernetes/letsencrypt/letsencrypt-prod.yaml
@@ -1,0 +1,18 @@
+  apiVersion: cert-manager.io/v1alpha2
+  kind: Issuer
+  metadata:
+    name: letsencrypt-prod
+  spec:
+    acme:
+      # The ACME server URL
+      server: https://acme-v02.api.letsencrypt.org/directory
+      # Email address used for ACME registration
+      email: info@bonkeybong.com
+      # Name of a secret used to store the ACME account private key
+      privateKeySecretRef:
+        name: letsencrypt-prod-private-key
+      # Enable the HTTP-01 challenge provider
+      solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/kubernetes/letsencrypt/letsencrypt-staging.yaml
+++ b/kubernetes/letsencrypt/letsencrypt-staging.yaml
@@ -1,0 +1,18 @@
+  apiVersion: cert-manager.io/v1alpha2
+  kind: Issuer
+  metadata:
+    name: letsencrypt-staging
+  spec:
+    acme:
+      # The ACME server URL
+      server: https://acme-staging-v02.api.letsencrypt.org/directory
+      # Email address used for ACME registration
+      email: info@bonkeybong.com
+      # Name of a secret used to store the ACME account private key
+      privateKeySecretRef:
+        name: letsencrypt-staging-private-key
+      # Enable the HTTP-01 challenge provider
+      solvers:
+      - http01:
+          ingress:
+            class: nginx


### PR DESCRIPTION
- New annotations and configuration for integrating Lets Encrypt with the cert-manager
- cert-manager is great but it's got an alpha API and will continue to change rapidly. I think it's worth the pain, as it will keep working in old versions unless Lets Encrypt changes their API, which seems unlikely given how many sites rely on it
- The dev cert-manager setup is likely broken now. This can be reviewed and merged and I will work on fixing dev before the next deployment
- Adds letsencrypt issuer k8s resources for cert-manager to repo