### PR TITLE
cover cases where org or user aren't in state

### DIFF
--- a/web/src/client/js/components/Permission/OrgPermission.js
+++ b/web/src/client/js/components/Permission/OrgPermission.js
@@ -9,10 +9,10 @@ const OrgPermission = ({ children, elseRender, acceptedRoleIds = [], acceptedSet
   const { data: organization, loading: orgLoading } = useDataService(dataMapper.organizations.current())
 
   // check if either user or org loading hasn't been triggered yet, or is currently loading, if so always return null
-  if (userLoading || userLoading == null) {
+  if (userLoading || userLoading == null || !currentUser) {
     return <>{null}</>
   }
-  if (orgLoading || orgLoading == null) {
+  if (orgLoading || orgLoading == null || !organization) {
     return <>{null}</>
   }
 


### PR DESCRIPTION
I couldn't reproduce the issue from the deployed app locally, but it seems like we could have a race condition of some kind so I added checks that the items we're looking at are populated

Make sure the web org permissions access stuff is working, then after merging we'll get this up on dev