### PR TITLE
Render blank doc when document loading/switching

### DIFF
--- a/web/src/client/js/components/Document/DocumentContainer.js
+++ b/web/src/client/js/components/Document/DocumentContainer.js
@@ -13,6 +13,10 @@ import { DOCUMENT_MODE, PRODUCT_NAME, PATH_DOCUMENT_NEW_PARAM } from 'Shared/con
 import DocumentComponent from './DocumentComponent'
 import NoDocument from './NoDocument'
 
+const defaultDocument = {
+  name: ''
+}
+
 const DocumentContainer = ({
   documentMode,
   isCreating,
@@ -30,6 +34,7 @@ const DocumentContainer = ({
     location.pathname
   ])
 
+  let currentDocument = document
 
   /**
    * If we're creating a document, render nothing
@@ -50,7 +55,7 @@ const DocumentContainer = ({
   }
 
   //if we're done loading things but the data never arrives, assume 404
-  if (documentLoading === false && !document) {
+  if (documentLoading === false && !currentDocument) {
     return <NoDocument />
   }
 
@@ -60,10 +65,20 @@ const DocumentContainer = ({
   }
 
   //things are still loading, return null
-  if (!project || !document) return null
+  if (!project) return null
 
-  //the current document doesn't match the url params, return null
-  if (document.id !== Number(match.params.documentId)) return null
+  // The current document doesn't match the url params, usually because
+  // the user has switched docs and the new doc hasn't loaded from currentResource helper.
+  // In that case, we want to render a blank document
+  if (currentDocument && currentDocument.id !== Number(match.params.documentId)) {
+    currentDocument = defaultDocument
+  }
+
+  // If there's no current doc, we still want to render the doc
+  // layout so the UI doesn't jump around
+  if (!currentDocument) {
+    currentDocument = defaultDocument
+  }
 
   /**
    * Otherwise we render the document, and update its values onChange
@@ -88,11 +103,11 @@ const DocumentContainer = ({
   return (
     <>
       <Helmet>
-        <title>{project.name}: {document.name} –– {PRODUCT_NAME}</title>
+        <title>{project.name}: {currentDocument.name} –– {PRODUCT_NAME}</title>
       </Helmet>
 
       <DocumentComponent
-        document={document}
+        document={currentDocument}
         documentMode={documentMode}
         isFullScreen={isFullScreen}
         nameChangeHandler={nameChangeHandler}


### PR DESCRIPTION
This prevents an unsightly flash when switching between docs, where the bottom document toolbar renders first, then the document title and text area