### PR TITLE
Moving Back to on Users view

### DIFF
--- a/web/src/client/js/components/Admin/AdminDashboardComponent.js
+++ b/web/src/client/js/components/Admin/AdminDashboardComponent.js
@@ -1,7 +1,7 @@
 import React, { lazy } from 'react'
 import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
-import { Link, NavLink, Redirect } from 'react-router-dom'
+import { NavLink, Redirect } from 'react-router-dom'
 
 import {
   ORGANIZATION_ROLE_IDS,
@@ -11,7 +11,7 @@ import {
   PLAN_TYPES,
   MULTI_USER_PLAN_TYPES
 } from 'Shared/constants'
-import { ArrowIcon, TeamsIcon, OrganizationIcon, BillingIcon } from 'Components/Icons'
+import { TeamsIcon, OrganizationIcon, BillingIcon } from 'Components/Icons'
 import { Panel, PanelNavigation, PanelContent } from 'Components/Panel'
 import OrgPlanPermission from 'Components/Permission/OrgPlanPermission'
 import OrgPermission from 'Components/Permission/OrgPermission'
@@ -59,11 +59,6 @@ const AdminDashboardComponent = ({ organization, section }) => {
       <main>
         <Panel>
           <PanelNavigation>
-            {section === 'user' &&
-            <Link to={`${PATH_ADMIN}/users`} className="link--back">
-              <ArrowIcon direction="left" /><span className="label">Back to Users</span>
-            </Link>
-            }
             <OrgPlanPermission acceptedPlans={MULTI_USER_PLAN_TYPES}>
               <NavLink to={`${PATH_ADMIN}/${ADMIN_PATHS.USERS}`} aria-label="Users" isActive={isSubSection}>
                 <TeamsIcon width="22" height="22" /> <span className="label">Users</span>

--- a/web/src/client/js/components/Admin/AdminUserView/AdminUserViewComponent.js
+++ b/web/src/client/js/components/Admin/AdminUserView/AdminUserViewComponent.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
+import { Link } from 'react-router-dom'
 
-import { RemoveIcon } from 'Components/Icons'
-import { ORGANIZATION_ROLE_IDS } from 'Shared/constants'
+import { ArrowIcon, RemoveIcon } from 'Components/Icons'
+import { ORGANIZATION_ROLE_IDS, PATH_ADMIN } from 'Shared/constants'
 import OrgRolesDropdown from 'Components/RolesDropdowns/OrgRolesDropdown'
 import ProjectRolesDropdown from 'Components/RolesDropdowns/ProjectRolesDropdown'
 import Table from 'Components/Table/Table'
@@ -56,6 +57,9 @@ const AdminUserViewComponent = ({
 
   return (
     <div className="admin-user">
+      <Link to={`${PATH_ADMIN}/users`} className="link--back">
+        <ArrowIcon direction="left" /><span className="label">Back to Users</span>
+      </Link>
       <header className="header">
         <h2>{user.name}</h2>
       </header>


### PR DESCRIPTION
Moves "Back to Users" from above the navigation to above the content, consistent with other Panel UIs. This is on the User view in Admin Users