### PR TITLE
1Password Generator fix

### DIFF
--- a/web/src/client/js/components/User/UserSecurity/UserSecurityFields.js
+++ b/web/src/client/js/components/User/UserSecurity/UserSecurityFields.js
@@ -49,7 +49,7 @@ const UserSecurityFields = ({ fieldsReadyHandler, fieldsShouldReset }) => {
     setConfirmStatus(null)
   }
 
-  const passwordValidationHandler = debounce(500, (password) => {
+  const passwordValidationHandler = (password) => {
     // Reset it all if we're blank
     if (password === '' || password.length === 0) {
       resetPassword()
@@ -82,9 +82,8 @@ const UserSecurityFields = ({ fieldsReadyHandler, fieldsShouldReset }) => {
     // Ok we'll allow this password, now match it
     if (password.length >= MIN_PASSWORD_LENGTH) {
       setPasswordStatus(null)
-      setNewPassword(password)
     }
-  })
+  }
 
   const passwordMatchHandler = debounce(500, (pw) => {
     if (pw !== newPassword) {
@@ -110,7 +109,7 @@ const UserSecurityFields = ({ fieldsReadyHandler, fieldsShouldReset }) => {
         status={passwordIsValid() && <CheckIcon fill="#51a37d" />}
         type="password"
       />
-      {(passwordStatus || passwordSummary) &&
+      {(passwordStatus || passwordSummary && passwordSummary.length > 0) &&
       <div name="pw-popover" role="alert">
         {passwordStatus &&
         <div className="data">


### PR DESCRIPTION
Removing debounce on pw change handler fixes the problem

Before:
Generate a new password and fill it here: http://localhost:3000/d/settings/security
The password's would both match, but react state was off, so it would tell you they didn't

After:
You can generate a password, fill it, and you won't get the warning