### PR TITLE
Actually do audit logging

### DIFF
--- a/api/src/integrators/audit.js
+++ b/api/src/integrators/audit.js
@@ -8,7 +8,7 @@ import { AUDIT_LOG_TOKEN } from '../constants/logging'
 let logger
 
 if (AUDIT_LOG_TOKEN) {
-  const logger = new Logger({
+  logger = new Logger({
     token: AUDIT_LOG_TOKEN,
     region: 'us'
   })


### PR DESCRIPTION
Ah the silent code failure of redeclaring a variable in a nested scope. Tested locally, it actually logs to insight ops now.

I did have this working before, I can see audit logs from right after Thanksgiving, but maybe I broke it in the final PR. I dunno.