### PR TITLE
Fixing empty search results

### DIFF
--- a/web/src/client/js/components/DocumentsList/DocumentsListComponent.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListComponent.js
@@ -227,7 +227,7 @@ const DocumentsListComponent = ({
           </IconButton>
         </ProjectPermission>
       </header>
-      {documents.length === 0 && loading === false && !creating &&
+      {documents.length === 0 && loading === false && !creating && !isSearching &&
       <div className="documents-list__empty-state">
         <div className="documents-list__empty-state-content notice">
           <div className="notice__icon">

--- a/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
@@ -133,8 +133,8 @@ const DocumentsListContainer = ({
     }
   })
 
-  let sortedSearchResults = []
-  if (searchResults) {
+  let sortedSearchResults = null
+  if (searchResults && searchTerm) {
     sortedSearchResults = Object.values(searchResults)
     sortedSearchResults.sort((a, b) => {
       return new Date(b.updatedAt) - new Date(a.updatedAt)
@@ -157,7 +157,7 @@ const DocumentsListContainer = ({
       createCallback={createDocumentHandler}
       createChangeHandler={createDocumentAction}
       creating={ui.documents.creating || documentId === PATH_DOCUMENT_NEW_PARAM}
-      documents={sortedSearchResults.length > 0 ? sortedSearchResults : sortedDocuments}
+      documents={sortedSearchResults ? sortedSearchResults : sortedDocuments}
       draggedDocumentHandler={draggedDocumentHandler}
       fieldCopyHandler={fieldCopyHandler}
       fieldMoveHandler={fieldMoveHandler}


### PR DESCRIPTION
* Does a check for isSearching because if documents is empty, it was thinking it was a new, empty  project
* Sets searchResults var to null by default, and a check if it's valid vs an empty array
