### PR TITLE
audit backup job kubernetes setup

### DIFF
--- a/docs/infrastructure/kube-jobs-setup.md
+++ b/docs/infrastructure/kube-jobs-setup.md
@@ -1,0 +1,9 @@
+# Kubernetes Job Setup
+
+This one is pretty easy:
+`kubectl create -f kubernetes/jobs`
+
+Jobs are _not_ automatically deployed to the cluster, they are not part of the Portway helm chart!
+
+If you update any job config, you will need to reapply the changes manually:
+`kubectl apply -f kubernetes/jobs`

--- a/docs/infrastructure/kube-secrets-setup.md
+++ b/docs/infrastructure/kube-secrets-setup.md
@@ -2,26 +2,38 @@
 
 Adding secrets is done manually to a cluster. You must connect locally to the cluster with `kubectl` and run the following commands, substituting appropriate `value`'s:
 
+Token secrets
 ```
 kubectl create secret generic token-secrets --from-literal=jwt_secret='value' --from-literal=password_reset='value'
 ```
 
+Stripe secrets
 ```
 kubectl create secret generic stripe-secrets --from-literal=secret='value' --from-literal=hook_secret='value'
 ```
 
+AWS secrets
 ```
 kubectl create secret generic aws-secrets --from-literal=access_key_id='value' --from-literal=secret_access_key='value'
 ```
 
+Database secrets
 ```
 kubectl create secret generic db-secrets --from-literal=db_user_password='value'
 ```
 
+Log secrets
 ```
 kubectl create secret generic log-secrets --from-literal=log_token='value' --from-literal=audit_log_token='value'
 ```
 
+Admin secrets
 ```
 kubectl create secret generic admin-secrets --from-literal=admin_secret_key='value'
+```
+
+Audit Log Backup secrets
+These are only needed if the audit log should get backed up in the environment and the audit log backup job is running
+```
+kubectl create secret generic audit-log-backup --from-literal=access_key_id='value' --from-literal=secret_access_key='value' --from-literal=api_key='value' --from-literal=log_id='value'
 ```

--- a/kubernetes/jobs/auditLogBackup.yaml
+++ b/kubernetes/jobs/auditLogBackup.yaml
@@ -1,5 +1,3 @@
-application/job/cronjob.yaml 
-
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/kubernetes/jobs/auditLogBackup.yaml
+++ b/kubernetes/jobs/auditLogBackup.yaml
@@ -1,0 +1,50 @@
+application/job/cronjob.yaml 
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: audit-log-backup
+spec:
+  schedule: "0 9 * * *"
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          imagePullSecrets:
+          - name: regcred
+          restartPolicy: OnFailure
+          containers:
+          - name: audit_log_backup
+            image: bonkeybong/portway_audit_log_backup
+            env:
+            - name: S3_CONTENT_BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: audit-log-backup-config
+                  key: backup.s3_content_bucket
+            - name: AWS_SES_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: audit-log-backup-config
+                  key: backup.aws_ses_region
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: audit-log-backup
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: audit-log-backup
+                  key: secret_access_key
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: audit-log-backup
+                  key: api_key
+            - name: LOG_ID
+              valueFrom:
+                secretKeyRef:
+                  name: audit-log-backup
+                  key: log_id

--- a/kubernetes/jobs/configMaps.yaml
+++ b/kubernetes/jobs/configMaps.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+items:
+- apiVersion: v1
+  data:
+    backup.s3_content_bucket: "portway-logs"
+    backup.aws_ses_region: "us-west-2"
+  kind: ConfigMap
+  metadata:
+    name: audit-log-backup-config
+    namespace: default
+kind: List


### PR DESCRIPTION
- Adds audit backup job to kubernetes config
- Separate from the Portway helm chart because we probably won't run this in dev. Could turn into a chart later but that's not really that beneficial unless we're automatically deploying it to multiple environments
- Requires the actual job Docker image + code: https://github.com/BonkeyBong/portway-ops/pull/1
(note the Docker image is currently on Docker Hub and has been tested outside of k8s and is functional)
- `--dry-run` passes with the k8s files in this PR