### PR TITLE
rename cronjob parts to make them dns compatible with the kubes

### DIFF
--- a/kubernetes/jobs/auditLogBackup.yaml
+++ b/kubernetes/jobs/auditLogBackup.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: audit-log-backup
+  name: audit-log-backup-cronjob
 spec:
   schedule: "0 9 * * *"
   concurrencyPolicy: "Forbid"
@@ -13,7 +13,7 @@ spec:
           - name: regcred
           restartPolicy: OnFailure
           containers:
-          - name: audit_log_backup
+          - name: audit-log-backup
             image: bonkeybong/portway_audit_log_backup
             env:
             - name: S3_CONTENT_BUCKET

--- a/pipelines/deployProd.yml
+++ b/pipelines/deployProd.yml
@@ -11,8 +11,8 @@ steps:
     image: alpine
     commands:
       - cf_export VERSION_TAG="$(cat ./deploys/prod.txt)"
-  deploy_to_dev_cf_step:
-    title: Deploy to Dev Cluster
+  deploy_to_prod_cf_step:
+    title: Deploy to Prod Cluster
     image: codefresh/cfstep-helm:2.14.3
     environment:
       - CHART_REF=kubernetes/helm/portway


### PR DESCRIPTION
Got an error actually trying to create the cronjob, this fixed it. Currently deployed on prod.

Bonus: fixes naming in prod deployment pipeline