### PR TITLE
Fixing new document name

### DIFF
--- a/web/src/client/js/components/DocumentsList/_DocumentsList.scss
+++ b/web/src/client/js/components/DocumentsList/_DocumentsList.scss
@@ -150,6 +150,11 @@
         &::selection {
           background-color: var(--color-yellow);
         }
+        &:focus {
+          .using-mouse & {
+            border: thin solid transparent;
+          }
+        }
       }
       &:focus {
         background-color: var(--document-list-active-item);


### PR DESCRIPTION
This shouldn't have had a border:

<img width="376" alt="Screen Shot 2019-12-20 at 12 50 34 PM" src="https://user-images.githubusercontent.com/2809/71291377-51207600-2327-11ea-8eb8-8cf918147696.png">
