### PR TITLE
quote booleans in configmap for disable signup flag

### DIFF
--- a/kubernetes/helm/portway/templates/config.yaml
+++ b/kubernetes/helm/portway/templates/config.yaml
@@ -25,7 +25,7 @@ items:
     web.api_url: {{ printf "http://%s-api-service:%s" .Release.Name .Values.apiPort }}
     web.api_public_url: {{ printf "https://%s" .Values.apiPublicUrl }}
     web.stripe_publishable_key: {{ .Values.stripePublishableKey | quote }}
-    web.flag_disable_signup: {{ .Values.web.flagDisableSignup }}
+    web.flag_disable_signup: {{ .Values.web.flagDisableSignup | quote }}
   kind: ConfigMap
   metadata:
     name: web-config


### PR DESCRIPTION
Well, `--dry-run` on the helm chart install isn't super helpful in all cases, kubes does not like a boolean value, it needs the string in the configMap. Unfortunately `--dry-run` passes with or without the quote addition, but I believe this should fix the error as the deployment is error'ing out on that line