### PR TITLE
fix country value

### DIFF
--- a/web/src/client/js/components/Admin/AdminPayment/StripeComponent.js
+++ b/web/src/client/js/components/Admin/AdminPayment/StripeComponent.js
@@ -205,7 +205,7 @@ class StripeComponent extends React.Component {
   billingSubmitHandler(e) {
     e.preventDefault()
     const cardData = {
-      'address_country': this.formRef.current.country.value,
+      'address_country': this.formRef.current.elements.country.value,
       'address_zip': this.formRef.current.elements['postal-code'].value,
       'address_state': this.formRef.current.elements.state.value
     }


### PR DESCRIPTION
This gets the address info set correctly on the card, which comes back on the result object. We're still not storing any address info on customer billing, not sure if we'll want to do that.