### PR TITLE
making catchall client error more generic

### DIFF
--- a/web/src/client/js/api/index.js
+++ b/web/src/client/js/api/index.js
@@ -12,6 +12,10 @@ const baseURL = (new URL('api', API_PUBLIC_URL)).href
 const globalErrorCodes = [403, 404, 408, 500, 503]
 const validationCodes = [400, 402, 409, 413, 415]
 
+// Handles various uncatchable errors, like timeouts,
+// CORS errors, etc.
+const UNKNOWN_ERROR_CODE = 404
+
 const axiosInstance = axios.create({
   baseURL: baseURL,
   timeout: 0,
@@ -25,7 +29,7 @@ async function fetch(resource) {
     const { data: { data, page, perPage, total, totalPages }, status } = await axiosInstance.get(resource)
     return { data, status, page, perPage, total, totalPages }
   } catch (error) {
-    const { data, status } = error.response || { status: 408, data: {} }
+    const { data, status } = error.response || { status: UNKNOWN_ERROR_CODE, data: {} }
     if (status === 401) { logout() }
     return { data, status }
   }
@@ -36,7 +40,7 @@ async function add(resource, body) {
     const { data: { data }, status } = await axiosInstance.post(resource, body)
     return { data, status }
   } catch (error) {
-    const { data, status } = error.response || { status: 408, data: {} }
+    const { data, status } = error.response || { status: UNKNOWN_ERROR_CODE, data: {} }
     if (status === 401) { logout() }
     return { data, status }
   }
@@ -47,7 +51,7 @@ async function update(resource, body) {
     const { data: { data }, status } = await axiosInstance.put(resource, body)
     return { data, status }
   } catch (error) {
-    const { data, status } = error.response || { status: 408, data: {} }
+    const { data, status } = error.response || { status: UNKNOWN_ERROR_CODE, data: {} }
     if (status === 401) { logout() }
     return { data, status }
   }
@@ -61,7 +65,7 @@ async function remove(resource) {
     await axiosInstance.delete(resource)
     return {} // keep this here ^
   } catch (error) {
-    const { data, status } = error.response || { status: 408, data: {} }
+    const { data, status } = error.response || { status: UNKNOWN_ERROR_CODE, data: {} }
     if (status === 401) { logout() }
     return { data, status }
   }

--- a/web/src/client/js/components/Notifications/NotificationMessages.js
+++ b/web/src/client/js/components/Notifications/NotificationMessages.js
@@ -1,6 +1,13 @@
 import React from 'react'
 import { NOTIFICATION_RESOURCE, NOTIFICATION_TYPES, SUPPORT_EMAIL } from 'Shared/constants'
 
+const resourceStrings = {
+  [NOTIFICATION_RESOURCE.PROJECTS]: 'projects',
+  [NOTIFICATION_RESOURCE.PROJECT]: 'this project',
+  [NOTIFICATION_RESOURCE.DOCUMENTS]: "this project's documents",
+  [NOTIFICATION_RESOURCE.DOCUMENT]: 'this document'
+}
+
 export const getNotificationTitle = function(notification) {
   if (notification.type === NOTIFICATION_TYPES.ERROR) {
     switch (notification.code) {
@@ -26,16 +33,16 @@ export const getNotificationTitle = function(notification) {
 }
 
 export const getNotificationMessage = function(notification) {
-  const resourceStrings = {
-    [NOTIFICATION_RESOURCE.PROJECTS]: 'projects',
-    [NOTIFICATION_RESOURCE.PROJECT]: 'this project',
-    [NOTIFICATION_RESOURCE.DOCUMENTS]: 'this project\'s documents',
-    [NOTIFICATION_RESOURCE.DOCUMENT]: 'this document',
-  }
+  const errorMessage = resourceStrings[notification.resource]
   const errorMessages = {
-    403: `Sorry, you don\'t have access to ${resourceStrings[notification.resource]}`,
-    404: `Sorry, we couldn\'t find ${resourceStrings[notification.resource]}`,
-    500: (<>{`Something went wrong, and it\'s our fault. Try refreshing, or email`} <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.</>)
+    403: `Sorry, you don\'t have access to ${errorMessage || 'that'}`,
+    404: errorMessage ? `Sorry, we couldn\'t find ${errorMessage}` : '',
+    500: (
+      <>
+        {`Something went wrong, and it\'s our fault. Try refreshing, or email`}{' '}
+        <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.
+      </>
+    )
   }
   if (notification.type === NOTIFICATION_TYPES.ERROR) {
     return errorMessages[notification.code]


### PR DESCRIPTION
Browsers seem to log 404 as the response code from a CORS issue, and it sort of fits, the resource may exist but the client can't find it 🤷‍♀ 

To test, in the API's app.js comment out the CORS section toward the top