### PR TITLE
fixing seat discrepencies on web

### DIFF
--- a/web/src/client/js/components/Admin/AdminUsers/AdminUsersContainer.js
+++ b/web/src/client/js/components/Admin/AdminUsers/AdminUsersContainer.js
@@ -41,7 +41,9 @@ const AdminUsersContainer = ({
   const { data: { users = [], totalPages } } = useDataService(dataMapper.users.list(page, sortBy, sortMethod), [page, sortBy, sortMethod])
 
   const { data: { userSearchResults = [], totalSearchPages } } = useDataService(dataMapper.users.searchByName(searchTerm), [searchTerm])
-  const { data: seats } = useDataService(dataMapper.organizations.seats())
+  // setting `null` as the second arg to useDataService will force seats to reload whenever
+  // another action clears out seat data (eg adding/removing users)
+  const { data: seats } = useDataService(dataMapper.organizations.seats(), null)
 
   function addUserHandler(values) {
     createUser(values)

--- a/web/src/client/js/reducers/organizations.js
+++ b/web/src/client/js/reducers/organizations.js
@@ -96,10 +96,15 @@ export const organizations = (state = initialState, action) => {
       const billingById = { ...state.loading.billingById, [id]: false }
       const organizationToUpdate = { ...state.organizationsBillingById[id] }
       organizationToUpdate.subscription.totalSeats = seats
+      const seatsById = { ...state.seatsById }
+      if (seatsById[id]) {
+        seatsById[id].totalSeats = seats
+      }
       const organizationsBillingById = { ...state.organizationsBillingById, [id]: organizationToUpdate }
       return {
         ...state,
         organizationsBillingById,
+        seatsById,
         loading: { ...state.loading, billingById }
       }
     }
@@ -159,6 +164,18 @@ export const organizations = (state = initialState, action) => {
           seatsById: loadingById
         }
       }
+    }
+
+    case ActionTypes.REMOVE_USER:
+    case ActionTypes.RECEIVE_CREATED_USER: {
+      const id = state.currentOrganizationId
+      const seatsById = { ...state.seatsById }
+      const seatsByIdLoading = { ...state.loading.seatsById }
+      if (seatsById[id]) {
+        delete seatsById[id]
+        delete seatsByIdLoading[id]
+      }
+      return { ...state, seatsById, loading: { ...state.loading, seatsById: seatsByIdLoading } }
     }
 
     // Org removal

--- a/web/src/client/js/reducers/organizations.js
+++ b/web/src/client/js/reducers/organizations.js
@@ -171,11 +171,26 @@ export const organizations = (state = initialState, action) => {
       const id = state.currentOrganizationId
       const seatsById = { ...state.seatsById }
       const seatsByIdLoading = { ...state.loading.seatsById }
+      const organizationsBillingById = { ...state.organizationsBillingById }
+      const billingById = { ...state.loading.billingById }
+      if (organizationsBillingById[id]) {
+        delete organizationsBillingById[id]
+        delete billingById[id]
+      }
       if (seatsById[id]) {
         delete seatsById[id]
         delete seatsByIdLoading[id]
       }
-      return { ...state, seatsById, loading: { ...state.loading, seatsById: seatsByIdLoading } }
+      return {
+        ...state,
+        seatsById,
+        organizationsBillingById,
+        loading: {
+          ...state.loading,
+          seatsById: seatsByIdLoading,
+          billingById
+        }
+      }
     }
 
     // Org removal


### PR DESCRIPTION
Basically, updating state.organization.seatsById to remove it when users are added or removed, and when org seats are changed on the plan.

Fixes all the issues I could find on web. Opening a new ticket for the fact you can create more users on the API than your plan allows