### PR TITLE
Adding big invisible button

### DIFF
--- a/web/src/client/js/components/ContentMenu/ContentMenuContainer.js
+++ b/web/src/client/js/components/ContentMenu/ContentMenuContainer.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
 
-import { FIELD_LABELS } from 'Shared/constants'
-import { groupBy } from 'Shared/utilities'
+import { getNewNameInSequence } from 'Shared/utilities'
 import { createField } from 'Actions/field'
 import useDataService from 'Hooks/useDataService'
 import currentResource from 'Libs/currentResource'
@@ -21,21 +20,8 @@ const ContentMenuContainer = ({ createField, fields, location }) => {
 
   if (!project || !document) return null
 
-  /**
-   * If we have fields, break them up by type for field names
-   */
-  let fieldsByType
-
-  if (fields) {
-    fieldsByType = groupBy(fields, 'type')
-  } else {
-    fieldsByType = {}
-  }
-
   function fieldCreationHandler(fieldType) {
-    const typeFieldsInDocument = fieldsByType[fieldType]
-    const value = typeFieldsInDocument ? typeFieldsInDocument.length : 0
-    const newName = FIELD_LABELS[fieldType] + (value + 1)
+    const newName = getNewNameInSequence(fields, fieldType)
     createField(project.id, document.id, fieldType, {
       name: newName,
       type: fieldType
@@ -53,7 +39,7 @@ ContentMenuContainer.propTypes = {
 
 const mapStateToProps = (state) => {
   return {
-    fields: state.documentFields[state.documents.currentDocumentId]
+    fields: state.documentFields.documentFieldsById[state.documents.currentDocumentId]
   }
 }
 

--- a/web/src/client/js/components/Document/_Document.scss
+++ b/web/src/client/js/components/Document/_Document.scss
@@ -91,6 +91,10 @@
       transition: opacity 0.2s ease-in-out;
     }
 
+    &--edit-mode {
+      padding-bottom: 7rem;
+    }
+
     // When publishing a document, disable everything
     &--disabled {
       opacity: 0.4;

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
@@ -11,6 +11,7 @@ import FieldImageComponent from 'Components/FieldImage/FieldImageComponent'
 
 const DocumentFieldsComponent = ({
   createdFieldId,
+  createFieldHandler,
   disabled,
   documentMode,
   dragEndHandler,
@@ -34,6 +35,16 @@ const DocumentFieldsComponent = ({
     return field.type === FIELD_TYPES.TEXT
   })
   const lastTextFieldId = textFields.length > 0 ? textFields[textFields.length - 1].id : null
+
+  const bigInvisibleButton = (
+    <li className="document-field" key="bib">
+      <button
+        aria-label="Continue the document body"
+        className="btn btn--blank document-field__invisible-button"
+        onClick={createFieldHandler}
+      />
+    </li>
+  )
 
   function toggleSettingsFor(fieldId) {
     if (settingsForField === fieldId) {
@@ -123,6 +134,11 @@ const DocumentFieldsComponent = ({
     const fieldArray = []
     fields.forEach((field, index) => {
       fieldArray.push(renderFieldType(field, index))
+      // If we're at the last field, and that field is NOT a text field
+      if (index === fields.length - 1 && field.type !== FIELD_TYPES.TEXT) {
+        // append a big invisible button so that you can click there to continue the "body"
+        fieldArray.push(bigInvisibleButton)
+      }
     })
     return fieldArray
   }
@@ -142,6 +158,7 @@ const DocumentFieldsComponent = ({
 
 DocumentFieldsComponent.propTypes = {
   createdFieldId: PropTypes.number,
+  createFieldHandler: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   documentMode: PropTypes.string.isRequired,
   dragEndHandler: PropTypes.func.isRequired,

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import { FIELD_TYPES } from 'Shared/constants'
+import { DOCUMENT_MODE, FIELD_TYPES } from 'Shared/constants'
 import DocumentFieldComponent from './DocumentFieldComponent'
 import FieldTextComponent from 'Components/FieldText/FieldTextComponent'
 import FieldNumberComponent from 'Components/FieldNumber/FieldNumberComponent'
@@ -135,7 +135,11 @@ const DocumentFieldsComponent = ({
     fields.forEach((field, index) => {
       fieldArray.push(renderFieldType(field, index))
       // If we're at the last field, and that field is NOT a text field
-      if (index === fields.length - 1 && field.type !== FIELD_TYPES.TEXT) {
+      if (
+        index === fields.length - 1 &&
+        field.type !== FIELD_TYPES.TEXT &&
+        documentMode !== DOCUMENT_MODE.EDIT
+      ) {
         // append a big invisible button so that you can click there to continue the "body"
         fieldArray.push(bigInvisibleButton)
       }
@@ -144,6 +148,7 @@ const DocumentFieldsComponent = ({
   }
   const fieldsClasses = cx({
     'document__fields': true,
+    'document__fields--edit-mode': documentMode === DOCUMENT_MODE.EDIT,
     'document__fields--is-dragging': isDragging,
     'document__fields--disabled': isPublishing || disabled
   })

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -4,16 +4,17 @@ import { useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
 
 import { FIELD_TYPES } from 'Shared/constants'
-import { debounce, isAnyPartOfElementInViewport } from 'Shared/utilities'
+import { debounce, getNewNameInSequence, isAnyPartOfElementInViewport } from 'Shared/utilities'
 import useDataService from 'Hooks/useDataService'
 import dataMapper from 'Libs/dataMapper'
 import { uiConfirm } from 'Actions/ui'
-import { blurField, focusField, updateField, removeField, updateFieldOrder } from 'Actions/field'
+import { blurField, createField, focusField, updateField, removeField, updateFieldOrder } from 'Actions/field'
 
 import DocumentFieldsComponent from './DocumentFieldsComponent'
 
 const DocumentFieldsContainer = ({
   blurField,
+  createField,
   createdFieldId,
   documentMode,
   disabled,
@@ -45,6 +46,17 @@ const DocumentFieldsContainer = ({
   }, [fields])
 
   // Actions
+  function createTextFieldHandler() {
+    // This is triggered by the Big Invisible Button™
+    // It should append a new text field to the end of the document, making it seem as though the
+    // user is clicking to continue the document body
+    const newName = getNewNameInSequence(fields, FIELD_TYPES.TEXT)
+    createField(projectId, documentId, FIELD_TYPES.TEXT, {
+      name: newName,
+      type: FIELD_TYPES.TEXT
+    })
+  }
+
   function fieldDestroyHandler(fieldId, fieldType) {
     let type = 'field'
 
@@ -176,6 +188,7 @@ const DocumentFieldsContainer = ({
 
   return (
     <DocumentFieldsComponent
+      createFieldHandler={createTextFieldHandler}
       createdFieldId={createdFieldId}
       disabled={disabled}
       documentMode={documentMode}
@@ -199,6 +212,7 @@ const DocumentFieldsContainer = ({
 
 DocumentFieldsContainer.propTypes = {
   blurField: PropTypes.func.isRequired,
+  createField: PropTypes.func.isRequired,
   createdFieldId: PropTypes.number,
   disabled: PropTypes.bool.isRequired,
   documentMode: PropTypes.string,
@@ -223,6 +237,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   blurField,
+  createField,
   focusField,
   removeField,
   updateField,

--- a/web/src/client/js/components/DocumentFields/_DocumentField.scss
+++ b/web/src/client/js/components/DocumentFields/_DocumentField.scss
@@ -118,8 +118,10 @@
     color: var(--theme-text-color);
     font-size: 1.3rem; // 13px
     font-weight: 600;
+    min-height: unset;
     min-width: var(--field-name-width); // change this in DocumentFieldComponent.js as well
     outline: none;
+    padding: 0;
   }
 } // document-field__name
 
@@ -149,3 +151,9 @@
   }
 
 } // document-field__content
+
+.document-field__invisible-button {
+  cursor: text;
+  height: 88px;
+  width: 100%;
+}

--- a/web/src/client/js/components/DocumentsList/_DocumentsList.scss
+++ b/web/src/client/js/components/DocumentsList/_DocumentsList.scss
@@ -84,6 +84,7 @@
     input[type="search"] {
       appearance: none;
       border: thin solid transparent;
+      padding: 0;
       width: 100%;
       .using-mouse & {
         &:focus {

--- a/web/src/client/js/components/FieldText/FieldTextComponent.js
+++ b/web/src/client/js/components/FieldText/FieldTextComponent.js
@@ -18,7 +18,6 @@ const FieldTextComponent = ({ autoFocusElement, field, onBlur, onChange, onFocus
       },
       element: textRef.current,
       initialValue: field ? field.value : '',
-      placeholder: 'Your ideas here...',
       shortcuts: {
         drawImage: null,
         toggleFullScreen: null,

--- a/web/src/shared/utilities.js
+++ b/web/src/shared/utilities.js
@@ -1,3 +1,5 @@
+import { FIELD_LABELS } from 'Shared/constants'
+
 export const debounce = function(delay, fn) {
   let timerId
   return function(...args) {
@@ -33,6 +35,22 @@ export const groupBy = function(list, property) {
     object[key].push(listItem)
     return object
   }, {})
+}
+
+/**
+ * Returns a name for a new field prepended by the number of fields of that type
+ * This is used in places like the ContentMenu and the BigInvisibleButton™
+ */
+export const getNewNameInSequence = function(fields, fieldType) {
+  let fieldsByType
+  if (fields) {
+    fieldsByType = groupBy(fields, 'type')
+  } else {
+    fieldsByType = {}
+  }
+  const typeFieldsInDocument = fieldsByType[fieldType]
+  const value = typeFieldsInDocument ? typeFieldsInDocument.length : 0
+  return FIELD_LABELS[fieldType] + (value + 1)
 }
 
 export const isAnyPartOfElementInViewport = function(el) {


### PR DESCRIPTION
* Adds Big Invisible Button™ to the end of the document, if the last field of a document is not a text field
* This should give the appearance of one big continuing document body
* Fixes a bug in naming new fields with the appropriate number, so now fields should get autonamed correctly in order (field-number-1, field-number-2, etc)