### PR TITLE
Fixing roles buttons; Fixing focus styles

### DIFF
--- a/web/src/client/css/inc/_buttons.scss
+++ b/web/src/client/css/inc/_buttons.scss
@@ -137,6 +137,36 @@ button,
     }
   }
 
+  &--form {
+    background-color: var(--button-white-background);
+    border: thin solid var(--button-white-border);
+    color: inherit;
+    &:not([disabled]) {
+      @media (hover: hover) {
+        &:hover {
+          background-color: var(--button-white-background);
+          border: thin solid var(--button-white-border-hover);
+          color: inherit;
+        }
+      }
+      &:active {
+        background-color: var(--button-white-background);
+        color: inherit;
+      }
+      &:focus {
+        background-color: var(--button-white-background);
+        border: thin solid var(--color-blue);
+        outline: none;
+      }
+    }
+    &[aria-expanded="true"] {
+      background-color: var(--button-white-border-hover);
+      &:focus {
+        background-color: var(--button-white-border-hover);
+      }
+    }
+  }
+
   &--blank, &--like-a-link {
     background-color: transparent;
     border-radius: 0;

--- a/web/src/client/js/components/Admin/AdminUsers/AdminUsersCreateForm.js
+++ b/web/src/client/js/components/Admin/AdminUsers/AdminUsersCreateForm.js
@@ -1,12 +1,11 @@
-import React, { lazy, useState } from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
-const Select = lazy(() => import('react-select'))
-
 import { debounce } from 'Shared/utilities'
-import { ORGANIZATION_ROLE_IDS, ORGANIZATION_ROLE_NAMES } from 'Shared/constants'
+import { ORGANIZATION_ROLE_IDS } from 'Shared/constants'
 import SpinnerContainer from 'Components/Spinner/SpinnerContainer'
 import FormField from 'Components/Form/FormField'
+import OrgRolesDropdown from 'Components/RolesDropdowns/OrgRolesDropdown'
 import ValidationComponent from 'Components/Validation/ValidationComponent'
 
 const AdminUsersCreateForm = ({ cancelHandler, disabled, errors, submitHandler }) => {
@@ -21,11 +20,6 @@ const AdminUsersCreateForm = ({ cancelHandler, disabled, errors, submitHandler }
     submitHandler({ name, email, orgRole })
   }
 
-  const orgSelectObject = [
-    { value: ORGANIZATION_ROLE_IDS.USER, label: ORGANIZATION_ROLE_NAMES[ORGANIZATION_ROLE_IDS.USER] },
-    { value: ORGANIZATION_ROLE_IDS.ADMIN, label: ORGANIZATION_ROLE_NAMES[ORGANIZATION_ROLE_IDS.ADMIN] }
-  ]
-
   function isNameOrEmailBlank() {
     return name === undefined || email === undefined || disabled
   }
@@ -39,8 +33,16 @@ const AdminUsersCreateForm = ({ cancelHandler, disabled, errors, submitHandler }
           id="userName"
           label="Full name"
           name="name"
-          onChange={e => debounce(200, setName(e.target.value))}
-          onBlur={(e) => { setName(e.target.value)} }
+          onChange={(e) => {
+            if (e.target.value.length > 1) {
+              debounce(200, setName(e.target.value))
+            }
+          }}
+          onBlur={(e) => {
+            if (e.target.value.length > 1) {
+              setName(e.target.value)
+            }
+          }}
           placeholder="Enter a full name"
           required
         />
@@ -49,8 +51,16 @@ const AdminUsersCreateForm = ({ cancelHandler, disabled, errors, submitHandler }
           id="userEmail"
           label="Email address"
           name="email"
-          onChange={e => debounce(200, setEmail(e.target.value))}
-          onBlur={(e) => { setEmail(e.target.value)} }
+          onChange={(e) => {
+            if (e.target.value.length > 1) {
+              debounce(200, setEmail(e.target.value))
+            }
+          }}
+          onBlur={(e) => {
+            if (e.target.value.length > 1) {
+              setEmail(e.target.value)
+            }
+          }}
           placeholder="name@domain.com"
           required
           type="email"
@@ -59,14 +69,9 @@ const AdminUsersCreateForm = ({ cancelHandler, disabled, errors, submitHandler }
           <div className="field">
             <label htmlFor="orgRole">Select a Role</label>
             <div className="control">
-              <Select
-                className="react-select-container react-select-container--with-indicators"
-                classNamePrefix="react-select"
-                name="orgRole"
-                isSearchable={false}
-                onChange={(option) => { setOrgRole(option.value) }}
-                options={orgSelectObject}
-                defaultValue={orgSelectObject[0]}
+              <OrgRolesDropdown
+                defaultValue={orgRole}
+                onChange={(roleId) => { setOrgRole(roleId) }}
               />
               <ValidationComponent errors={errors.orgRole} />
             </div>

--- a/web/src/client/js/components/Menu/Menu.js
+++ b/web/src/client/js/components/Menu/Menu.js
@@ -7,16 +7,19 @@ import './_Menu.scss'
 const Menu = ({ anchorRef, className, children, isActive, ...props }) => {
   const [selectedIndex, setSelectedIndex] = useState(-1)
   const [menuItems, setMenuItems] = useState([])
+  const [activeFirstTime, setActiveFirstTime] = useState(true)
 
   const keyNavigationHandler = useCallback((e) => {
     let counterBecauseUseState = selectedIndex
 
     switch (e.key) {
       case 'ArrowDown':
+        e.preventDefault()
         // Increase the index
         setSelectedIndex(counterBecauseUseState++)
         break
       case 'ArrowUp':
+        e.preventDefault()
         // Decrease the index
         setSelectedIndex(counterBecauseUseState--)
         break
@@ -40,6 +43,10 @@ const Menu = ({ anchorRef, className, children, isActive, ...props }) => {
 
   useEffect(() => {
     if (isActive) {
+      if (activeFirstTime) {
+        anchorRef.current.focus()
+        setActiveFirstTime(false)
+      }
       const menuItemComponents = React.Children.toArray(children).filter((child) => {
         return child.type.name === 'MenuItem'
       })
@@ -57,8 +64,9 @@ const Menu = ({ anchorRef, className, children, isActive, ...props }) => {
     } else {
       // Reset once the menu is closed
       setSelectedIndex(-1)
+      setActiveFirstTime(true)
     }
-  }, [children, isActive, keyNavigationHandler])
+  }, [activeFirstTime, anchorRef, children, isActive, keyNavigationHandler])
 
   const menuClasses = cx({
     'menu': true,

--- a/web/src/client/js/components/Menu/_Menu.scss
+++ b/web/src/client/js/components/Menu/_Menu.scss
@@ -57,6 +57,9 @@
           border: transparent;
         }
       }
+      &:focus {
+        background-color: var(--menu-item-hover-background);
+      }
     }
   }
 

--- a/web/src/client/js/components/Menu/_Menu.scss
+++ b/web/src/client/js/components/Menu/_Menu.scss
@@ -26,9 +26,11 @@
 }
 
 .menu__item {
-  --menu-item-hover-background: var(--color-gray-5);
+  --menu-item-focus-background: var(--color-gray-5);
+  --menu-item-hover-background: var(--color-gray-10);
   @media (prefers-color-scheme: dark) {
-    --menu-item-hover-background: var(--color-gray-80);
+    --menu-item-focus-background: var(--color-gray-80);
+    --menu-item-hover-background: var(--color-gray-90);
   }
   outline: 0;
   padding: 0;
@@ -40,7 +42,7 @@
 
   button, .btn {
     background-color: transparent;
-    border: transparent;
+    border: thin solid transparent;
     font-size: 1.5rem;
     font-weight: 300;
     justify-content: flex-start;
@@ -54,11 +56,11 @@
       @media (hover: hover) {
         &:hover {
           background-color: var(--menu-item-hover-background);
-          border: transparent;
+          border: thin solid transparent;
         }
       }
       &:focus {
-        background-color: var(--menu-item-hover-background);
+        background-color: var(--menu-item-focus-background);
       }
     }
   }

--- a/web/src/client/js/components/RolesDropdowns/OrgRolesDropdown.js
+++ b/web/src/client/js/components/RolesDropdowns/OrgRolesDropdown.js
@@ -32,22 +32,33 @@ const OrgRolesDropdown = ({ align, buttonStyle, defaultValue, disabled, name, on
         aria-expanded={expanded}
         aria-haspopup="true"
         aria-controls="org-roles-dropdown"
-        className="btn btn--white btn--with-icon"
+        className="btn btn--form btn--with-icon"
         onClick={() => setExpanded(!expanded)}
         ref={anchorRef}
+        type="button"
       >
         <span className="label">{permissionMenuLabel}</span>
         <CaretIcon />
       </button>
       <Popper id="org-roles-dropdown" anchorRef={anchorRef} autoCollapse={collapseCallback} open={expanded} width="300">
-        <Menu anchorRef={anchorRef}>
+        <Menu anchorRef={anchorRef} isActive={expanded}>
           <MenuItem>
-            <button className="btn btn--blank" onClick={() => adjustRoleHandler(ORGANIZATION_ROLE_IDS.USER) }>
+            <button
+              className="btn btn--blank btn--menu-item"
+              onClick={() => adjustRoleHandler(ORGANIZATION_ROLE_IDS.USER) }
+              ref={React.createRef()}
+              type="button"
+            >
               {ORGANIZATION_ROLE_NAMES[ORGANIZATION_ROLE_IDS.USER]}
             </button>
           </MenuItem>
           <MenuItem>
-            <button className="btn btn--blank" onClick={() => adjustRoleHandler(ORGANIZATION_ROLE_IDS.ADMIN) }>
+            <button
+              className="btn btn--blank btn--menu-item"
+              onClick={() => adjustRoleHandler(ORGANIZATION_ROLE_IDS.ADMIN) }
+              ref={React.createRef()}
+              type="button"
+            >
               {ORGANIZATION_ROLE_NAMES[ORGANIZATION_ROLE_IDS.ADMIN]}
             </button>
           </MenuItem>

--- a/web/src/client/js/components/RolesDropdowns/ProjectRolesDropdown.js
+++ b/web/src/client/js/components/RolesDropdowns/ProjectRolesDropdown.js
@@ -39,21 +39,24 @@ const ProjectRolesDropdown = ({ align, defaultValue, disabled, onChange }) => {
         aria-expanded={expanded}
         aria-haspopup="true"
         aria-controls="project-role-dropdown"
-        className="btn btn--white btn--with-icon"
+        className="btn btn--form btn--with-icon"
         disabled={disabled}
         onClick={() => setExpanded(!expanded)}
         ref={anchorRef}
+        type="button"
       >
         <span className="label">{permissionMenuLabel}</span>
         <CaretIcon />
       </button>
       <Popper id="project-role-dropdown" anchorRef={anchorRef} align={align} autoCollapse={collapseCallback} open={expanded} width="300">
-        <Menu anchorRef={anchorRef}>
+        <Menu anchorRef={anchorRef} isActive={expanded}>
           <MenuItem>
             <button
-              className="btn btn--blank"
+              className="btn btn--blank btn--menu-item"
               onClick={() => adjustRoleHandler(PROJECT_ROLE_IDS.READER) }
               style={buttonStyleOverride}
+              ref={React.createRef()}
+              type="button"
             >
               {PROJECT_ROLE_NAMES[PROJECT_ROLE_IDS.READER]}
               <p className="small">
@@ -63,9 +66,11 @@ const ProjectRolesDropdown = ({ align, defaultValue, disabled, onChange }) => {
           </MenuItem>
           <MenuItem>
             <button
-              className="btn btn--blank"
+              className="btn btn--blank btn--menu-item"
               onClick={() => adjustRoleHandler(PROJECT_ROLE_IDS.CONTRIBUTOR) }
               style={buttonStyleOverride}
+              ref={React.createRef()}
+              type="button"
             >
               {PROJECT_ROLE_NAMES[PROJECT_ROLE_IDS.CONTRIBUTOR]}
               <p className="small">
@@ -76,9 +81,11 @@ const ProjectRolesDropdown = ({ align, defaultValue, disabled, onChange }) => {
           </MenuItem>
           <MenuItem>
             <button
-              className="btn btn--blank"
+              className="btn btn--blank btn--menu-item"
               onClick={() => adjustRoleHandler(PROJECT_ROLE_IDS.ADMIN) }
               style={buttonStyleOverride}
+              ref={React.createRef()}
+              type="button"
             >
               {PROJECT_ROLE_NAMES[PROJECT_ROLE_IDS.ADMIN]}
               <p className="small">

--- a/web/src/client/js/hooks/useDetectInputMode.js
+++ b/web/src/client/js/hooks/useDetectInputMode.js
@@ -24,6 +24,8 @@ function useDetectInputMode() {
     }
     function keyDownHandler(e) {
       if (inputTypesThatShouldntReturnTrue.includes(e.target.type)) return
+      if (e.target.classList.contains('btn--form')) return
+      if (e.target.classList.contains('btn--menu-item')) return
       if (e.key && e.key.toLowerCase() !== 'meta') {
         document.body.classList.remove('using-mouse')
       }


### PR DESCRIPTION
* Updates OrgRolesDropdown and ProjectRolesDropdown to use the nice keyboard navigation stuff added in the Search PR
* Changes "Add user" form to use OrgRolesDropdown instead of React Select
* Updates some styling so that focus is different depending on mouse-mode or keyboard-mode, so that Menu's focus the same as inputs in forms

To test:

* Click on the "Full name" field in "Add user" form. You should be able to tab through the "Add user" form, and use the arrow keys to navigate the dropdown - focus styles should be consistent
* If you tab TO the "Add user" form (keyboard-mode), the focus should be consistent here too
* Teams under Project settings should all work the same too

