### PR TITLE
DND bug fix - Switching to useRef

### DIFF
--- a/web/src/client/js/components/Document/_Document.scss
+++ b/web/src/client/js/components/Document/_Document.scss
@@ -87,6 +87,7 @@
   }
 
   &__fields {
+    padding-bottom: var(--brand-width);
     @media (prefers-reduced-motion: no-preference) {
       transition: opacity 0.2s ease-in-out;
     }

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -33,6 +33,8 @@ const DocumentFieldsContainer = ({
 
   let cloneElement
 
+  const [dropped, setDropped] = useState(false)
+
   // Convert fields object to a sorted array for rendering
   useEffect(() => {
     const fieldMap = Object.keys(fields).map((fieldId) => {
@@ -171,7 +173,9 @@ const DocumentFieldsContainer = ({
     e.stopPropagation()
     draggingElement.current.classList.remove('document-field--dragging')
     document.querySelector('#clone-element').remove()
+
     draggingElement.current = null
+    setDropped(!dropped)
   }
 
   // Prop handler
@@ -200,7 +204,7 @@ const DocumentFieldsContainer = ({
       fieldRenameHandler={debouncedNameChangeHandler}
       fields={orderedFields}
       fieldsUpdating={fieldsUpdating}
-      isDragging={draggingElement !== null}
+      isDragging={draggingElement.current != null}
       isPublishing={isPublishing}
     />
   )

--- a/web/src/client/js/components/DocumentFields/_DocumentField.scss
+++ b/web/src/client/js/components/DocumentFields/_DocumentField.scss
@@ -76,7 +76,7 @@
 
   .document__fields--is-dragging & {
     overflow: hidden;
-    height: 65px;
+    height: 100px;
   }
 
 } // document-field__component


### PR DESCRIPTION
Fixes drag and drop bug of dragEnd events triggering immediately after dragStart. This is what was getting "stuck".

React useState was causing a re-render, which would put the DOM in a weird state on dragStart. Switching to useRef to keep track of the draggingElement seems to have fixed it. 