### PR TITLE
DND - Changing height value

### DIFF
--- a/web/src/client/js/components/DocumentFields/_DocumentField.scss
+++ b/web/src/client/js/components/DocumentFields/_DocumentField.scss
@@ -76,7 +76,7 @@
 
   .document__fields--is-dragging & {
     overflow: hidden;
-    height: 100px;
+    max-height: 100px;
   }
 
 } // document-field__component


### PR DESCRIPTION
When dragging an element, set its max-height to 100, not height. This was making data fields, which are < 100px, look shitty. 