### PR TITLE
using API logging code on web

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -45,7 +45,6 @@ Make sure people know they need to update their local .env with the new value!
 **STRIPE_HOOK_SECRET**: The Stripe webhook secret  
 **S3_CONTENT_BUCKET**: The name of the S3 bucket where assets are stored  
 **CDN_HOSTNAME**: The FQDN of the Cloudfront CDN. No trailing slash  
-**LOGGER**: The logger the app should use. Valid values defined in `constants/logging.js`  
 **LOG_TOKEN**: When using the `r7insight` logger, the associated log token   
 **AUDIT_LOG_TOKEN**: When set, the `r7insight` logger is turned on for the audit log  
 **ADMIN_SECRET_KEY**: A secret key used for authorizing admin actions  
@@ -54,7 +53,10 @@ Make sure people know they need to update their local .env with the new value!
 **STRIPE_PUBLISHABLE_KEY**: The publishable key from Stripe. Used to manage subscriptions and collect payment info.  
 **API_URL**: The locally resolveable url to the API. In a kubernetes cluster, this may be `http://api-service:3001` for example.
 **API_PUBLIC_URL**: The publicly accessible FQDN for the API. Used to make API calls from the client javascript app.  
+**FLAG_DISABLE_SIGNUP**: Turns off the sign up form and endpoint when set to the string `true`  
+**LOG_TOKEN_WEB**: An r7insight token for web logging
 
 # Shared Environment Variables
 **JWT_SECRET**: A secret string used to sign and verify JSON Web Tokens used for app authentication  
-**FLAG_DISABLE_SIGNUP**: Turns off the sign up form and endpoint when set to the string `true`
+**LOGGER**: The logger the app should use. Valid values defined in `constants/logging.js`  
+

--- a/docs/infrastructure/kube-secrets-setup.md
+++ b/docs/infrastructure/kube-secrets-setup.md
@@ -24,7 +24,7 @@ kubectl create secret generic db-secrets --from-literal=db_user_password='value'
 
 Log secrets
 ```
-kubectl create secret generic log-secrets --from-literal=log_token='value' --from-literal=audit_log_token='value'
+kubectl create secret generic log-secrets --from-literal=log_token='value' --from-literal=audit_log_token='value' --from-literal=log_token_web='value'
 ```
 
 Admin secrets

--- a/kubernetes/helm/portway/templates/web-deployment.yaml
+++ b/kubernetes/helm/portway/templates/web-deployment.yaml
@@ -39,6 +39,11 @@ spec:
             configMapKeyRef:
               name: web-config
               key: web.api_public_url
+        - name: LOGGER
+          valueFrom:
+            configMapKeyRef:
+              name: api-config
+              key: api.logger
         - name: JWT_SECRET
           valueFrom:
             secretKeyRef:
@@ -59,6 +64,11 @@ spec:
             secretKeyRef:
               name: zendesk-secrets
               key: token
+        - name: LOG_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: log-secrets
+              key: log_token_web
         ports:
         - containerPort: 3000
           protocol: TCP

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4939,6 +4939,14 @@
         "babel-plugin-jest-hoist": "^24.1.0"
       }
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -5908,6 +5916,14 @@
       "dev": true,
       "requires": {
         "typo-js": "*"
+      }
+    },
+    "codependency": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/codependency/-/codependency-2.1.0.tgz",
+      "integrity": "sha512-JIdmYkE8Z6jwH1OUf4a5H5jk9YShPQkaYPUAiN+ktyChmPP77LGbeKrxWGPqdCnpTmt0hRIn8TXBVu01U3HDhg==",
+      "requires": {
+        "semver": "^5.3.0"
       }
     },
     "collection-visit": {
@@ -6926,6 +6942,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
       "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==",
       "dev": true
+    },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -12400,8 +12421,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.1.0",
@@ -12822,8 +12842,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -15255,6 +15274,11 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -15589,6 +15613,17 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
+    },
+    "r7insight_node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/r7insight_node/-/r7insight_node-2.0.0.tgz",
+      "integrity": "sha512-ss3LCo0dk6I3vcVmMfc4JImcIC4C8NBEmiCDYc0TWGNSZSD2tRV6D2nCwNf0iOUlZDsTW+SwBgQ1hrn0ykhmDw==",
+      "requires": {
+        "codependency": "^2.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "reconnect-core": "^1.3.0"
+      }
     },
     "raf": {
       "version": "3.4.1",
@@ -15984,6 +16019,14 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "reconnect-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reconnect-core/-/reconnect-core-1.3.0.tgz",
+      "integrity": "sha1-+65SkZp4d9hE4yRtAaLyZwHIM8g=",
+      "requires": {
+        "backoff": "~2.5.0"
       }
     },
     "redent": {

--- a/web/package.json
+++ b/web/package.json
@@ -113,6 +113,7 @@
     "body-parser": "^1.18.3",
     "connect-gzip-static": "^2.1.1",
     "cookie-parser": "^1.4.4",
+    "cuid": "^2.1.8",
     "debug": "~2.6.9",
     "ejs": "~2.5.7",
     "express": "^4.16.4",
@@ -122,6 +123,7 @@
     "passport": "^0.4.0",
     "passport-custom": "^1.0.5",
     "passport-jwt": "^4.0.0",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "r7insight_node": "^2.0.0"
   }
 }

--- a/web/src/server/app.js
+++ b/web/src/server/app.js
@@ -11,10 +11,17 @@ import cookieParser from 'cookie-parser'
 import { normalizePort, renderBundles } from './libs/express-utilities'
 import controllerLoader from './controllers/loader'
 import portwayMiddleware from './libs/portwayMiddleware'
+import httpLogger from './libs/httpLogger'
+import uncaughtErrorHandler from './libs/uncaughtErrorHandler'
 
 import { SUPPORT_LINK } from '../shared/constants'
 
+// Setup a listener on uncaught errors to log them
+uncaughtErrorHandler()
+
 const app = express()
+app.use(httpLogger)
+
 const port = normalizePort(process.env.PORT || '3000')
 const devMode = process.env.NODE_ENV !== 'production'
 

--- a/web/src/server/constants.js
+++ b/web/src/server/constants.js
@@ -1,2 +1,25 @@
 
 export const SIGNUP_DISABLED = process.env.FLAG_DISABLE_SIGNUP === 'true'
+
+export const LOG_TOKEN_WEB = process.env.LOG_TOKEN_WEB
+
+// NOTE: if you change these levels, make sure
+// the r7 insights logger will accept them!
+export const LOG_LEVELS = {
+  INFO: 'info',
+  WARNING: 'warning',
+  ERROR: 'err'
+}
+
+export const LOGGER_TYPES = {
+  R7_INSIGHT: 'r7insight',
+  CONSOLE: 'console'
+}
+
+export const DEFAULT_LOG_LEVEL = LOG_LEVELS.INFO
+
+export const LOGGER = process.env.LOGGER || LOGGER_TYPES.CONSOLE
+
+console.info(`Logger: ${LOGGER}`)
+
+

--- a/web/src/server/libs/httpLogger.js
+++ b/web/src/server/libs/httpLogger.js
@@ -1,0 +1,74 @@
+/**
+ * Middleware request logger for Portway
+ */
+import logger from './logger'
+import { LOG_LEVELS } from '../constants'
+/* eslint-disable camelcase */
+
+// Keys are the key that will be logged, and values are functions that will
+// be passed the express req, res vars at the end of a request. Functions must
+// be synchronous and return a value for the given key
+const endFuncs = {
+  url: (req) => {
+    return req.originalUrl || req.url
+  },
+  // endpoint: (req) => {
+  //   // Turn the url into a route-like endpoint
+  //   // eg 'api/v1/users/12' becomes 'api/v1/users/:id'
+  //   // Makes log aggregation much simpler to dig into endpoint performance
+  //   const url = req.originalUrl || req.url
+  //   const path = url.split('?')[0].split('/')
+  //   return path.map(i => i.replace(/^\d+$/, ':id')).join('/')
+  // },
+  method: req => req.method,
+  status: (req, res) => res.statusCode,
+  ip: (req) => {
+    return (
+      req.ip || req._remoteAddress || (req.connection && req.connection.remoteAddress) || undefined
+    )
+  },
+  http_version: (req) => {
+    return req.httpVersionMajor + '.' + req.httpVersionMinor
+  },
+  user_id: (req) => {
+    return req.user ? req.user.id : null
+  },
+  user_agent: req => req.headers['user-agent'],
+  res_size: (req, res) => {
+    return res.getHeader('content-length')
+  },
+  res_time: (req) => {
+    const endAt = process.hrtime()
+    const startAt = req._portwayHttpLog.startAt
+    if (!startAt) {
+      return
+    }
+    // Calculation from morgan
+    // https://github.com/expressjs/morgan/blob/master/index.js#L235
+    const ms = (endAt[0] - startAt[0]) * 1e3 + (endAt[1] - startAt[1]) * 1e-6
+
+    return ms.toFixed(2)
+  },
+  time: req => req._portwayHttpLog.startTime
+}
+
+const httpLogger = (req, res, next) => {
+  if (req.method === 'OPTIONS') return next()
+
+  req._portwayHttpLog = {} // Setup namespace
+  req._portwayHttpLog.startAt = process.hrtime()
+  req._portwayHttpLog.startTime = Date.now()
+
+  res.on('finish', () => {
+    const reqLog = Object.keys(endFuncs).reduce((log, key) => {
+      log[key] = endFuncs[key].call(this, req, res)
+      return log
+    }, {})
+
+    logger(LOG_LEVELS.INFO, reqLog)
+  })
+
+  next()
+}
+
+export default httpLogger

--- a/web/src/server/libs/logger.js
+++ b/web/src/server/libs/logger.js
@@ -1,0 +1,55 @@
+import Logger from 'r7insight_node'
+import {
+  LOGGER,
+  LOG_TOKEN_WEB,
+  LOG_LEVELS,
+  DEFAULT_LOG_LEVEL,
+  LOGGER_TYPES
+} from '../constants'
+import { processId } from './uniqueId'
+
+const VALID_LOG_LEVEL_VALUES = Object.values(LOG_LEVELS)
+
+let logger
+
+switch (LOGGER) {
+  case LOGGER_TYPES.R7_INSIGHT:
+    logger = new Logger({
+      token: LOG_TOKEN_WEB,
+      region: 'us',
+      console: true, // send output to console too
+      withStack: true // expands error objects with stack in logs
+    })
+
+    logger.on('error', (err) => {
+      console.error('R7 Insight Logger Error')
+      console.error(err)
+    })
+    break
+  default:
+    // eslint-disable-next-line no-console
+    logger = console
+}
+
+export default (level, message) => {
+  // First arg is optional level. If only one arg passed, it's the log message so give it the
+  // default log level
+  if (!message) {
+    message = level
+    level = DEFAULT_LOG_LEVEL
+  } else {
+    if (!VALID_LOG_LEVEL_VALUES.includes(level)) {
+      throw new Error(`${level} is not a valid log level, must be one of ${VALID_LOG_LEVEL_VALUES}`)
+    }
+  }
+
+  if (typeof message === 'string') {
+    message = { message }
+  }
+
+  // Add the machine id to anything logged
+  // eslint-disable-next-line camelcase
+  message.machine_id = processId
+
+  logger.log(level, message)
+}

--- a/web/src/server/libs/uncaughtErrorHandler.js
+++ b/web/src/server/libs/uncaughtErrorHandler.js
@@ -1,0 +1,10 @@
+import { LOG_LEVELS } from '../constants'
+import logger from './logger'
+
+const uncaughtErrorHandler = () => {
+  process.on('unhandledRejection', (error) => {
+    logger(LOG_LEVELS.ERROR, { error })
+  })
+}
+
+export default uncaughtErrorHandler

--- a/web/src/server/libs/uniqueId.js
+++ b/web/src/server/libs/uniqueId.js
@@ -1,0 +1,8 @@
+import cuid from 'cuid'
+
+// Generate a unique id when loaded
+export const processId = cuid()
+
+export const generateId = () => {
+  return cuid()
+}


### PR DESCRIPTION
Not very DRY, but why reinvent the wheel?

Allows us to look at web server performance, and add logging for specific web server events in the future.

To test, add the env vars in 1pass for the web .env. You'll need to `make installweb` as well