### PR TITLE
updates to rate limiter with redis

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -60,6 +60,7 @@
     "ejs": "^3.0.1",
     "express": "^4.16.4",
     "hashids": "^1.2.2",
+    "ioredis": "^4.14.1",
     "joi": "^14.3.1",
     "jsonwebtoken": "^8.4.0",
     "markdown-it": "^10.0.0",

--- a/api/src/libs/rateLimiter.js
+++ b/api/src/libs/rateLimiter.js
@@ -1,4 +1,5 @@
 import SlidingWindowRateLimiter from 'sliding-window-rate-limiter'
+import IORedis from 'ioredis'
 /*
 ## check(key, limit)
 const result = await limiter.check(key, limit)
@@ -19,7 +20,10 @@ const options = {
 }
 
 if (process.env.REDIS_URL) {
-  options.redis = process.env.REDIS_URL
+  // sliding-window-rate-limiter is supposed to take a url to redis, but
+  // it doesn't seem to work. Much safer to just pass an ioredis instance
+  const redis = new IORedis(process.env.REDIS_URL)
+  options.redis = redis
 }
 
 const limiter = SlidingWindowRateLimiter.createLimiter(options)

--- a/docs/kubernetes-docker-examples.md
+++ b/docs/kubernetes-docker-examples.md
@@ -1,0 +1,21 @@
+# Useful Things with Kubernetes and Docker
+
+## Expose a Kubernetes Service to local Docker
+
+1. Connect to the desired kubernetes cluster with kubectl
+```
+kubectl config get-contexts
+kubectl config use-context [context name]
+```
+
+2. Find and expose the service
+```
+kubectl get services
+kubectl port-forward svc/[service name] [local port]:[service port]
+// eg: kubectl port-forward svc/redis-service 7000:6379
+```
+
+3. Connect to the service with Docker
+Docker exposes the magic `host.docker.internal` inside containers. Using this url, we can connect to port 7000 on localhost in a locally running Docker container.  
+In the appropriate `.env` file (or wherever you can set an env var): `REDIS_URL=host.docker.internal:7000`  
+Now running the docker container will allow it to connect to the Kubernetes service!


### PR DESCRIPTION
The behavior of sliding-window-rate-limiter is weird when given a string to a redis url. If I run a local redis server I can connect to it fine, but as soon as I port forwarded the redis instance running on the dev cluster I could no longer connect to it, even though the redis-cli could connect just fine.

So turns out passing an instance of ioredis (used by sliding-window-rate-limiter) is the best path forward. Works locally with the port-forwarded redis instance from the kubes