### PR TITLE
Public / Read-only project fixes

### DIFF
--- a/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
+++ b/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
@@ -4,14 +4,12 @@ import { useLocation, useParams, withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
 
 import * as strings from 'Loc/strings'
-import { MULTI_USER_PLAN_TYPES, PATH_DOCUMENT_NEW_PARAM } from 'Shared/constants'
-import { currentUserId } from 'Libs/currentIds'
+import { PATH_DOCUMENT_NEW_PARAM } from 'Shared/constants'
 
 import { deleteDocument, publishDocument, unpublishDocument } from 'Actions/document'
 import { uiConfirm } from 'Actions/ui'
 import useDataService from 'Hooks/useDataService'
 import currentResource from 'Libs/currentResource'
-import dataMapper from 'Libs/dataMapper'
 
 import DocumentToolbarComponent from './DocumentToolbarComponent'
 
@@ -27,30 +25,14 @@ const DocumentToolbarContainer = ({
 }) => {
   const { documentId, projectId } = useParams()
   const location = useLocation()
-  const { data: currentOrg } = useDataService(dataMapper.organizations.current())
   const { data: document } = useDataService(currentResource('document', location.pathname), [
     location.pathname
   ])
-  const { data: projectAssignments, loading: assignmentsLoading } = useDataService(dataMapper.projects.projectAssignments(projectId), [projectId])
-  const { data: users, loading: userLoading } = useDataService(dataMapper.users.list())
 
   if (!document) return null
 
   if (isCreating && documentId === PATH_DOCUMENT_NEW_PARAM) {
     return null
-  }
-
-  // Create a list of projectUsers if we have any
-  let projectUsers = []
-  if (MULTI_USER_PLAN_TYPES.includes(currentOrg.plan)) {
-    const myUserId = String(currentUserId)
-    if (!userLoading && !assignmentsLoading && projectAssignments) {
-      projectUsers = Object.keys(projectAssignments).filter((userId) => {
-        if (userId !== myUserId) {
-          return users[userId]
-        }
-      })
-    }
   }
 
   function publishDocumentHandler() {
@@ -84,7 +66,6 @@ const DocumentToolbarContainer = ({
       documentMode={documentMode}
       isCreating={isCreating}
       isPublishing={isPublishing}
-      projectUsers={projectUsers}
       publishDocumentHandler={publishDocumentHandler}
       removeDocumentHandler={removeDocumentHandler}
       unpublishDocumentHandler={unpublishDocumentHandler}

--- a/web/src/client/js/components/DocumentsList/DocumentsListComponent.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListComponent.js
@@ -26,6 +26,7 @@ const DocumentsListComponent = ({
   fieldMoveHandler,
   loading,
   projectId,
+  readOnly,
   removeDocumentHandler,
   searchDocumentsHandler,
   unpublishDocumentHandler,
@@ -232,8 +233,14 @@ const DocumentsListComponent = ({
           <div className="notice__icon">
             <DocumentIcon fill={colorSurface} width="32" height="32" />
           </div>
-          <h2 className="notice__headline">Get started</h2>
+          {readOnly &&
+          <>
+            <h2 className="notice__headline">An empty project!?</h2>
+            <p>Check back later to see your team’s hard work.</p>
+          </>
+          }
           <ProjectPermission acceptedRoleIds={[PROJECT_ROLE_IDS.ADMIN, PROJECT_ROLE_IDS.CONTRIBUTOR]}>
+            <h2 className="notice__headline">Get started</h2>
             <p>Create a new document, or drag a bunch of text documents here to get started.</p>
             <button className="btn btn--small notice__action" name="addDocument" onClick={() => { createCallback(true) }}>Create document</button>
           </ProjectPermission>
@@ -266,6 +273,7 @@ DocumentsListComponent.propTypes = {
   fieldMoveHandler: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   projectId: PropTypes.number.isRequired,
+  readOnly: PropTypes.bool.isRequired,
   removeDocumentHandler: PropTypes.func.isRequired,
   searchDocumentsHandler: PropTypes.func.isRequired,
   unpublishDocumentHandler: PropTypes.func.isRequired,

--- a/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
@@ -4,7 +4,12 @@ import { useHistory, useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
 
 import * as strings from 'Loc/strings'
-import { PATH_DOCUMENT_NEW, PATH_DOCUMENT_NEW_PARAM, PATH_PROJECT } from 'Shared/constants'
+import {
+  PATH_DOCUMENT_NEW,
+  PATH_DOCUMENT_NEW_PARAM,
+  PATH_PROJECT,
+  PROJECT_ROLE_IDS,
+} from 'Shared/constants'
 import { debounce } from 'Shared/utilities'
 
 import useDataService from 'Hooks/useDataService'
@@ -35,9 +40,13 @@ const DocumentsListContainer = ({
   const { documentId, projectId } = useParams()
   const history = useHistory()
 
-  const { data: documents, loading } = useDataService(dataMapper.documents.list(projectId), [
-    projectId
-  ])
+  const { data: documents, loading } = useDataService(dataMapper.documents.list(projectId), [projectId])
+  const { data: projectAssignments, loading: assignmentsLoading } = useDataService(dataMapper.users.currentUserProjectAssignments())
+
+  let readOnly = null
+  if (assignmentsLoading === false) {
+    readOnly = projectAssignments[projectId] === undefined || projectAssignments[projectId].role === PROJECT_ROLE_IDS.READER
+  }
 
   // trigger clear search action if project id changes
   useEffect(() => {
@@ -163,6 +172,7 @@ const DocumentsListContainer = ({
       fieldMoveHandler={fieldMoveHandler}
       loading={loading}
       projectId={Number(projectId)}
+      readOnly={readOnly}
       removeDocumentHandler={removeDocumentHandler}
       searchDocumentsHandler={searchDocumentsHandler}
       unpublishDocumentHandler={unpublishDocumentHandler}

--- a/web/src/client/js/components/ProjectsList/ProjectsListItem.js
+++ b/web/src/client/js/components/ProjectsList/ProjectsListItem.js
@@ -1,16 +1,20 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-import React, { useRef } from 'react'
+import React, { lazy, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
-import { MULTI_USER_PLAN_TYPES, PATH_PROJECT, PROJECT_ROLE_IDS } from 'Shared/constants'
-import { ProjectIcon, SettingsIcon, TrashIcon } from 'Components/Icons'
+import { MULTI_USER_PLAN_TYPES, PATH_PROJECT, PROJECT_ACCESS_LEVELS, PROJECT_ROLE_IDS } from 'Shared/constants'
+import { ProjectIcon, SettingsIcon, TrashIcon, UnlockIcon } from 'Components/Icons'
 import OrgPlanPermission from 'Components/Permission/OrgPlanPermission'
 import ProjectPermission from 'Components/Permission/ProjectPermission'
-import ProjectUsersContainer from 'Components/ProjectUsers/ProjectUsersContainer'
+
+// Lazy loading because not all users have access to this
+const ProjectUsersContainer = lazy(() => import(/* webpackChunkName: 'ProjectUsersContainer' */ 'Components/ProjectUsers/ProjectUsersContainer'))
 
 const ProjectsListItem = ({ history, projectId, project, handleDelete }) => {
   const itemRef = useRef()
+  const assignedProject = project.accessLevel == null
+  const publiclyReadable = project.accessLevel === PROJECT_ACCESS_LEVELS.READ
 
   function itemClickHandler(e) {
     if (e.target === itemRef.current) {
@@ -37,24 +41,34 @@ const ProjectsListItem = ({ history, projectId, project, handleDelete }) => {
           </div>
         </div>
         <OrgPlanPermission acceptedPlans={MULTI_USER_PLAN_TYPES}>
+          {assignedProject &&
           <div className="project-list__team">
             <ProjectUsersContainer collapsed={true} projectId={projectId} />
           </div>
+          }
         </OrgPlanPermission>
       </Link>
       <div className="project-list__actions" ref={itemRef}>
+        {publiclyReadable &&
+        <div className="project-list__public-token">
+          <UnlockIcon width="18" height="18" />
+          <span className="label">Everyone</span>
+        </div>
+        }
         <ProjectPermission acceptedRoleIds={[PROJECT_ROLE_IDS.ADMIN]} projectIdOverride={projectId}>
-          <Link aria-label="Project settings" to={`/project/${projectId}/settings`} className="btn btn--blank">
-            <SettingsIcon />
-          </Link>
-          <button
-            aria-label="Delete project"
-            name="deleteProject"
-            className="btn btn--blank"
-            onClick={handleDelete}
-          >
-            <TrashIcon />
-          </button>
+          <div className="project-list__action-buttons">
+            <Link aria-label="Project settings" to={`/project/${projectId}/settings`} className="btn btn--blank">
+              <SettingsIcon />
+            </Link>
+            <button
+              aria-label="Delete project"
+              name="deleteProject"
+              className="btn btn--blank"
+              onClick={handleDelete}
+            >
+              <TrashIcon />
+            </button>
+          </div>
         </ProjectPermission>
       </div>
     </li>

--- a/web/src/client/js/components/ProjectsList/_ProjectList.scss
+++ b/web/src/client/js/components/ProjectsList/_ProjectList.scss
@@ -107,6 +107,15 @@
       margin-right: 1rem;
     }
 
+    &__public-token {
+      align-items: center;
+      display: flex;
+      font-size: 1.2rem;
+      .label {
+        padding: .2rem 0 0 .6rem;
+      }
+    }
+
     &__team {
       align-items: center;
       display: flex;
@@ -124,8 +133,9 @@
       background-color: var(--project-actions-color);
       align-items: center;
       display: flex;
-      justify-content: flex-end;
-      padding: 0 1rem;
+      justify-content: space-between;
+      min-height: 3.8rem;
+      padding: 0 1.5rem 0 1.5rem;
       a, button {
         font-size: 1.2rem;
         margin-left: 1rem;
@@ -143,6 +153,11 @@
           }
         }
       }
+    }
+
+    &__action-buttons {
+      flex: 1;
+      text-align: right;
     }
 
   }


### PR DESCRIPTION
* Marks a project as public in the project list
* Removes unnecessary loading of ProjectUsersContainer if the user can't see it
* Removes users query in the DocumentToolbar, which caused the 404 on a project