### PR TITLE
clear out user project list when new project created

### DIFF
--- a/web/src/client/js/reducers/userAssignments.js
+++ b/web/src/client/js/reducers/userAssignments.js
@@ -47,6 +47,7 @@ export const userAssignments = (state = initialState, action) => {
     // to force a refetch
     case ActionTypes.RECEIVE_CREATED_PROJECT: {
       return {
+        ...state,
         assignmentsByUserId: {},
         loading: {
           byUserId: {}

--- a/web/src/client/js/reducers/userProjects.js
+++ b/web/src/client/js/reducers/userProjects.js
@@ -30,6 +30,15 @@ export const userProjects = (state = initialState, action) => {
         loading: { ...state.loading, byUserId: { ...state.loading.byUserId, ...loadingByUserId } }
       }
     }
+    case ActionTypes.RECEIVE_CREATED_PROJECT: {
+      return {
+        ...state,
+        projectsByUserId: {},
+        loading: {
+          byUserId: {}
+        }
+      }
+    }
     default:
       return state
   }


### PR DESCRIPTION
when a new project is created, clears out user projects and loading state so that they are refetched in the admin section