### PR TITLE
Fixing keys list and endpoints

### DIFF
--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokenItem.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokenItem.js
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import Constants from 'Shared/constants'
 import { TrashIcon } from 'Components/Icons'
@@ -7,16 +8,22 @@ import ClipboardComponent from 'Components/Clipboard/ClipboardComponent'
 
 const ProjectSettingsTokenItem = ({ removeHandler, selected, selectHandler, token }) => {
   const tokenRef = useRef()
+  const pillClasses = cx({
+    'pill': true,
+    'pill--green': selected,
+  })
   return (
     <li key={`token-${token.id}`} className={`project-settings__token-list-item${selected ? ' project-settings__token-list-item--selected' : '' }`}>
-      <input type="radio" name="project-token" defaultChecked={selected} onClick={() => { selectHandler(token.id) }} />
       <div className="project-settings__token-list-item__info">
         <div className="project-settings__token-list-item__details">
           <span className="project-settings__token-list-item__name">{token.name}</span>
         </div>
         <div className="project-settings__token-list-item__token">
           <div className="project-settings__token-list-item__field">
-            <label htmlFor={`token-${token.id}`} className="pill">{Constants.PROJECT_ROLE_NAMES[token.roleId]}</label>
+            <label>
+              <input type="radio" name="project-token" defaultChecked={selected} onClick={() => { selectHandler(token.id) }} />
+              <span className={pillClasses}>{Constants.PROJECT_ROLE_NAMES[token.roleId]}</span>
+            </label>
             <input readOnly type="text" value={token.token} ref={tokenRef} id={`token-${token.id}`} />
           </div>
           <ClipboardComponent copyRef={tokenRef} />

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokenList.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokenList.js
@@ -27,6 +27,7 @@ const ProjectSettingsTokenList = ({ selectedToken, tokens, tokenRemoveHandler, t
 ProjectSettingsTokenList.propTypes = {
   selectedToken: PropTypes.number,
   tokens: PropTypes.array.isRequired,
+  tokenRemoveHandler: PropTypes.func.isRequired,
   tokenSelectHandler: PropTypes.func.isRequired
 }
 

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokensComponent.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokensComponent.js
@@ -75,11 +75,9 @@ const ProjectSettingsTokensComponent = ({
           </dt>
           <dd className="project-settings__endpoint">
             <pre>
-              <code className="code">
-                <span className="code__block-comment"># Get the project documents using the selected token</span>
-                <span className="code__command">curl</span> -H &quot;Authorization: Bearer <span className="project-settings__endpoint-token">{selectedToken.token}</span>&quot; \<br />
-                <span className="project-settings__endpoint-url">{PRODUCT_API_URL}projects/{projectId}/documents</span>
-              </code>
+              <span className="code__block-comment"># Get the project documents using the selected token</span>
+              <span className="code__command">curl</span> -H &quot;Authorization: Bearer <span className="project-settings__endpoint-token">{selectedToken.token}</span>&quot; \<br />
+              <span className="project-settings__endpoint-url">{PRODUCT_API_URL}projects/{projectId}/documents</span>
             </pre>
             <textarea
               ref={getEndpointRef}

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/_ProjectSettingsTokens.scss
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/_ProjectSettingsTokens.scss
@@ -1,10 +1,5 @@
 // Tokens
 .project-settings {
-  --endpoint-name-background: var(--color-gray-40);
-  @media (prefers-color-scheme: dark) {
-    --endpoint-name-background: var(--color-gray-70);
-  }
-
   // Token list
   &__token-list {
     list-style: none;
@@ -61,7 +56,9 @@
 
   // Endpoints
   &__endpoint-name {
-    background-color: var(--endpoint-name-background);
+    background-color: var(--theme-overflow);
+    border: thin solid var(--theme-border);
+    border-bottom: none;
     align-items: center;
     display: flex;
     justify-content: space-between;

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/_ProjectSettingsTokens.scss
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/_ProjectSettingsTokens.scss
@@ -70,16 +70,13 @@
   &__endpoint {
     display: block;
     pre {
+      overflow-x: auto;
       width: 100%;
-    }
-    code {
-      display: block;
-      max-width: 800px;
-      overflow-x: scroll;
+      white-space: pre-wrap;
+      word-break: break-all;
     }
     &-token {
       color: var(--color-gray-10);
-      word-break: break-all;
     }
     &-url {
       color: var(--color-green);

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/_ProjectSettingsTokens.scss
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/_ProjectSettingsTokens.scss
@@ -15,13 +15,11 @@
     align-items: center;
     display: flex;
     input[type="radio"] {
-      margin-right: 1.8rem;
+      margin-right: .6rem;
     }
     &__info {
-      border: thin solid var(--theme-border);
       flex: 1;
       margin-bottom: 2rem;
-      padding: 1rem;
     }
     &__details {
       align-items: flex-start;
@@ -34,15 +32,12 @@
     }
     &__field {
       align-items: center;
-      border: thin solid var(--theme-border);
-      border-radius: var(--border-radius);
       display: flex;
       width: 100%;
       .pill {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
         font-size: 1.2rem;
-        margin: 0;
         padding: 2px 6px;
       }
       input {
@@ -55,7 +50,7 @@
     &__token {
       align-items: center;
       display: flex;
-      input {
+      input[type="text"] {
         flex: 1;
       }
       .btn {
@@ -76,12 +71,18 @@
     flex: 1;
   }
   &__endpoint {
-    display: flex;
+    display: block;
     pre {
       width: 100%;
     }
+    code {
+      display: block;
+      max-width: 800px;
+      overflow-x: scroll;
+    }
     &-token {
       color: var(--color-gray-10);
+      word-break: break-all;
     }
     &-url {
       color: var(--color-green);


### PR DESCRIPTION
This wasn't just on the iPad. Regular Safari and other browsers looked dumb once a key was selected

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/2809/73112329-cd781d00-3ec2-11ea-99b6-74dabc1c0a36.png">
