### PR TITLE
Fixing CodeMirror font color for dark mode

### DIFF
--- a/web/src/client/js/components/DocumentFields/_DocumentField.scss
+++ b/web/src/client/js/components/DocumentFields/_DocumentField.scss
@@ -4,10 +4,12 @@
 .document-field {
   --field-edit-mode-background: hsla(0, 0%, 95%, 90%);
   --field-name-width: 150px;
+  --field-data-name-color: hsla(0, 0%, 26%, .5);
   --field-data-background: var(--theme-overflow);
   --field-data-border: var(--color-gray-10);
   --field-dragging-background: var(--color-gray-5);
   @media (prefers-color-scheme: dark) {
+    --field-data-name-color: hsla(0, 0%, 100%, .2);
     --field-data-background: var(--theme-overlay-dark);
     --field-data-border: var(--theme-overlay-light);
     --field-dragging-background: var(--theme-base);
@@ -129,7 +131,7 @@
   }
 
   &-label {
-    color: hsla(0, 0%, 26%, .5);
+    color: var(--field-data-name-color);
     font-size: 1.3rem;
     @include media('>medium') {
       margin-bottom: .6rem;

--- a/web/src/client/js/components/FieldText/FieldText.scss
+++ b/web/src/client/js/components/FieldText/FieldText.scss
@@ -10,6 +10,7 @@
   .CodeMirror {
     background-color: transparent;
     border: none;
+    color: var(--theme-text-color);
     padding: 0;
     border-radius: 0;
     height: auto;


### PR DESCRIPTION
<img width="761" alt="image" src="https://user-images.githubusercontent.com/2809/73204198-655c4d80-40f3-11ea-9049-2ed1b8e00624.png">
