### PR TITLE
fix log token name in kube web deployment

### DIFF
--- a/kubernetes/helm/portway/templates/web-deployment.yaml
+++ b/kubernetes/helm/portway/templates/web-deployment.yaml
@@ -64,7 +64,7 @@ spec:
             secretKeyRef:
               name: zendesk-secrets
               key: token
-        - name: LOG_TOKEN
+        - name: LOG_TOKEN_WEB
           valueFrom:
             secretKeyRef:
               name: log-secrets


### PR DESCRIPTION
web deployment erroring out because the exposed env var name was wrong :(