### PR TITLE
Updating project team menu

### DIFF
--- a/web/src/client/css/inc/_react-select.scss
+++ b/web/src/client/css/inc/_react-select.scss
@@ -82,9 +82,6 @@ form {
         outline: none;
       }
     }
-    &__indicators {
-      display: none;
-    }
     &__placeholder {
       color: var(--react-select-placeholder-color);
       + div {

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsComponent.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsComponent.js
@@ -37,7 +37,7 @@ const ProjectSettingsComponent = ({ projectId, setting }) => {
         </NavLink>
         <OrgPlanPermission acceptedPlans={MULTI_USER_PLAN_TYPES}>
           <NavLink to={`${settingsSectionPath}/${SETTINGS_PATHS.TEAMS}`} aria-label="Teams">
-            <TeamsIcon /> <span className="label">Teams</span>
+            <TeamsIcon /> <span className="label">Team</span>
           </NavLink>
         </OrgPlanPermission>
         <NavLink to={`${settingsSectionPath}/${SETTINGS_PATHS.KEYS}`} aria-label="API Keys">

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
@@ -43,9 +43,9 @@ const ProjectSettingsTeamsComponent = ({
                 inputId="team-list"
                 isClearable={true}
                 onInputChange={debounce((input, { action }) => {
-                  if (action === 'input-change') {
+                  if (action === 'input-change' || action === 'menu-close') {
                     setNewUserId(null)
-                    userSearchHandler(input)
+                    userSearchHandler(input || '')
                   }
                 }, 400)}
                 options={users}

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
@@ -41,6 +41,7 @@ const ProjectSettingsTeamsComponent = ({
                 className="react-select-container"
                 defaultValue={newUserId}
                 inputId="team-list"
+                isClearable={true}
                 onInputChange={debounce((input, { action }) => {
                   if (action === 'input-change') {
                     setNewUserId(null)
@@ -48,7 +49,9 @@ const ProjectSettingsTeamsComponent = ({
                   }
                 }, 400)}
                 options={users}
-                onChange={(option) => { setNewUserId(Number(option.value)) }}
+                onChange={(option) => {
+                  option && option.value ? setNewUserId(Number(option.value)) : setNewUserId(null)
+                }}
                 placeholder="Add a person..."
                 ref={selectRef} />
             </div>

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
@@ -47,7 +47,7 @@ const ProjectSettingsTeamsComponent = ({
                     setNewUserId(null)
                     userSearchHandler(input)
                   }
-                  if (action === 'memnu-close') {
+                  if (action === 'menu-close') {
                     userSearchHandler('')
                   }
                 }, 400)}

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsComponent.js
@@ -43,9 +43,12 @@ const ProjectSettingsTeamsComponent = ({
                 inputId="team-list"
                 isClearable={true}
                 onInputChange={debounce((input, { action }) => {
-                  if (action === 'input-change' || action === 'menu-close') {
+                  if (action === 'input-change') {
                     setNewUserId(null)
-                    userSearchHandler(input || '')
+                    userSearchHandler(input)
+                  }
+                  if (action === 'memnu-close') {
+                    userSearchHandler('')
                   }
                 }, 400)}
                 options={users}

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsContainer.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsContainer.js
@@ -39,8 +39,9 @@ const ProjectSettingsTeamContainer = ({ location }) => {
   })
 
   let unassignedUsers = []
+
   const searchResults = searchUsers && searchUsers.userSearchResults
-  const resultsOrLoadedUsers = searchResults ? searchResults : loadedUsers.users
+  const resultsOrLoadedUsers = userSearch ? searchResults : loadedUsers.users
   if (resultsOrLoadedUsers) {
     unassignedUsers = Object.values(resultsOrLoadedUsers).filter((user) => {
       if (projectAssignments[user.id]) return
@@ -72,9 +73,7 @@ const ProjectSettingsTeamContainer = ({ location }) => {
   }
 
   function userSearchHandler(partialNameString) {
-    if (partialNameString) {
-      setUserSearch(partialNameString)
-    }
+    setUserSearch(partialNameString)
   }
 
   return (

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsContainer.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsContainer.js
@@ -24,6 +24,7 @@ const ProjectSettingsTeamContainer = ({ location }) => {
   const { data: projectUsers } = useDataService(dataMapper.projects.projectUsers(projectId))
   const { data: currentUser } = useDataService(dataMapper.users.current())
   const { data: projectAssignments } = useDataService(dataMapper.projects.projectAssignments(projectId))
+  const { data: loadedUsers } = useDataService(dataMapper.users.list(1))
   const { data: searchUsers = {} } = useDataService(dataMapper.users.searchByName(userSearch), [userSearch])
 
   if (!currentUser || !projectUsers || !projectAssignments || !Object.keys(project).length) return null
@@ -38,8 +39,10 @@ const ProjectSettingsTeamContainer = ({ location }) => {
   })
 
   let unassignedUsers = []
-  if (searchUsers && searchUsers.userSearchResults) {
-    unassignedUsers = Object.values(searchUsers.userSearchResults).filter((user) => {
+  const searchResults = searchUsers && searchUsers.userSearchResults
+  const resultsOrLoadedUsers = searchResults ? searchResults : loadedUsers.users
+  if (resultsOrLoadedUsers) {
+    unassignedUsers = Object.values(resultsOrLoadedUsers).filter((user) => {
       if (projectAssignments[user.id]) return
       return user
     })


### PR DESCRIPTION
Almost fixes it all, I need help with one thing.

1. This will load the first page of users by default in the menu
2. Start typing a name you know doesn't exist (zz)
3. Now delete the (zz) and see it goes back to the initial list
4. Now type "b" and see the Baddys and Biddys
5. Now delete the b, and you'll see that the searchResults still have the Baddys and Biddys loaded, but they shouldn't be... because the setState() in the container should have reset userSearch results

Is this a problem with passing null as a value to dataMapper? 