### PR TITLE
docs! In kubernetes!

### DIFF
--- a/kubernetes/helm/portway/prodValues.yaml
+++ b/kubernetes/helm/portway/prodValues.yaml
@@ -14,12 +14,13 @@ redisPort: "6379"
 stripePublishableKey: "pk_live_aZuMG4Z30RhPg54H8JFQOEKJ"
 
 apiImage: bonkeybong/portway_api
-apiTag: "0.9.1"
+apiTag: "0.12.1"
 
 webImage: bonkeybong/portway_web
-webTag: "0.9.1"
+webTag: "0.12.1"
 
 web:
+  port: "3000"
   flagDisableSignup: "true"
 
 api:

--- a/kubernetes/helm/portway/prodValues.yaml
+++ b/kubernetes/helm/portway/prodValues.yaml
@@ -7,6 +7,7 @@ certIssuer: letsencrypt-prod
 
 baseUrl: portway.app
 apiPublicUrl: api.portway.app
+docsUrl: docs.portway.app
 apiPort: "3001"
 redisPort: "6379"
 
@@ -33,9 +34,15 @@ db:
   name: "defaultdb"
   useSsl: "true"
 
+docs:
+  image: 'bonkeybong/portway_docs'
+  tag: 'latest'
+  port: "3003"
+
 serviceNames:
   api: api
   web: web
   db: db
   redis: redis
+  docs: docs
 

--- a/kubernetes/helm/portway/templates/docs-deployment.yaml
+++ b/kubernetes/helm/portway/templates/docs-deployment.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docs-deployment
+  labels:
+    app: {{ .Values.serviceNames.docs }}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: {{ .Values.serviceNames.docs }}
+  template:
+    metadata:
+      labels:
+        run: {{ .Values.serviceNames.docs }}
+        app: {{ .Values.serviceNames.docs }}
+    spec:
+      imagePullSecrets:
+      - name: regcred    
+      containers:
+      - image: {{ printf "%s:%s" .Values.docs.image .Values.docs.tag }}
+        name: {{ .Values.serviceNames.docs }}
+        ports:
+        - containerPort: {{ .Values.docs.port }}
+          protocol: TCP

--- a/kubernetes/helm/portway/templates/docs-service.yaml
+++ b/kubernetes/helm/portway/templates/docs-service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-docs-service
+spec:
+  selector:
+    app: {{ .Values.serviceNames.docs }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.docs.port }}
+    targetPort: {{ .Values.docs.port }}

--- a/kubernetes/helm/portway/templates/ingress.yaml
+++ b/kubernetes/helm/portway/templates/ingress.yaml
@@ -11,6 +11,7 @@ spec:
   - hosts:
     - {{ .Values.baseUrl }}
     - {{ .Values.apiPublicUrl }}
+    - {{ .Values.docsUrl }}
     secretName: {{ .Values.certIssuer }}-cert
   rules:
   - host: {{ .Values.apiPublicUrl }}
@@ -18,13 +19,19 @@ spec:
       paths:
       - backend:
           serviceName: {{ .Release.Name }}-api-service
-          servicePort: 3001
+          servicePort: {{ .Values.apiPort }}
   - host: {{ .Values.baseUrl }}
     http:
       paths:
       - backend:
           serviceName: {{ .Release.Name }}-web-service
-          servicePort: 3000
+          servicePort: {{ .Values.web.port }}
+  - host: {{ .Values.docsUrl }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Release.Name }}-docs-service
+          servicePort: {{ .Values.docs.port }}
 ---
 apiVersion: v1
 data:

--- a/kubernetes/helm/portway/templates/redis-deployment.fixme
+++ b/kubernetes/helm/portway/templates/redis-deployment.fixme
@@ -1,4 +1,4 @@
-# Remove this comment and rename to .yaml
+# Remove this comment and rename to .yaml to re-enable
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes/helm/portway/values.yaml
+++ b/kubernetes/helm/portway/values.yaml
@@ -2,7 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-certIssuer: letsencrypt-staging
+# Lets Encrypt cert issuer
+certIssuer: letsencrypt-prod
 
 baseUrl: dev.portway.app
 apiPublicUrl: api.dev.portway.app
@@ -13,10 +14,10 @@ redisPort: "6379"
 stripePublishableKey: "pk_test_1pwhBFZzMbjvUlsgn2EjsfWP"
 
 apiImage: bonkeybong/portway_api
-apiTag: "0.11.0"
+apiTag: "0.12.1"
 
 webImage: bonkeybong/portway_web
-webTag: "0.11.0"
+webTag: "0.12.1"
 
 web:
   port: "3000"
@@ -27,17 +28,17 @@ api:
   s3ContentBucket: 'portway-content-dev'
   logger: 'r7insight'
 
-docs:
-  image: 'bonkeybong/portway_docs'
-  tag: 'latest'
-  port: "3003"
-
 db:
   host: "dev-db-portway-do-user-2269753-0.db.ondigitalocean.com"
   port: "25060"
   user: "doadmin"
   name: "defaultdb"
   useSsl: "true"
+
+docs:
+  image: 'bonkeybong/portway_docs'
+  tag: 'latest'
+  port: "3003"
 
 serviceNames:
   api: api

--- a/kubernetes/helm/portway/values.yaml
+++ b/kubernetes/helm/portway/values.yaml
@@ -2,10 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-certIssuer: letsencrypt-prod
+certIssuer: letsencrypt-staging
 
 baseUrl: dev.portway.app
 apiPublicUrl: api.dev.portway.app
+docsUrl: docs.dev.portway.app
 apiPort: "3001"
 redisPort: "6379"
 
@@ -18,12 +19,18 @@ webImage: bonkeybong/portway_web
 webTag: "0.11.0"
 
 web:
+  port: "3000"
   flagDisableSignup: "false"
 
 api:
   cdnHostname: 'https://dev.portwaycontent.com'
   s3ContentBucket: 'portway-content-dev'
   logger: 'r7insight'
+
+docs:
+  image: 'bonkeybong/portway_docs'
+  tag: 'latest'
+  port: "3003"
 
 db:
   host: "dev-db-portway-do-user-2269753-0.db.ondigitalocean.com"
@@ -37,4 +44,5 @@ serviceNames:
   web: web
   db: db
   redis: redis
+  docs: docs
 


### PR DESCRIPTION
kube config for docs on dev and prod

Will apply to prod after review, going to do it manually rather than via the pipeline deployment so I can switch the issuer to letsencrypt-staging to make sure it works before hitting strict rate limits from the prod issuer with letsencrypt.

Also requires an update to the existing load balancer service to fix in-cluster routing. 99% sure this will fix the redis issues too. The only reason our app works is because we're running 2 instances of each web and api and k8s prefers running the pods on separate nodes (aka vms) when possible. Otherwise if web was running on a node and the api was running on a separate node they wouldn't actually be able to communicate with each other. Fun times.