### PR TITLE
Fixing user menu focus flashes

### DIFF
--- a/web/src/client/js/components/Menu/_Menu.scss
+++ b/web/src/client/js/components/Menu/_Menu.scss
@@ -3,6 +3,9 @@
   margin: 0;
   min-width: 200px;
   padding: .7rem 0;
+  &:focus {
+    outline: none;
+  }
 }
 
 .menu__header {

--- a/web/src/client/js/components/UserMenu/UserMenu.scss
+++ b/web/src/client/js/components/UserMenu/UserMenu.scss
@@ -20,7 +20,7 @@
     overflow: hidden;
     text-indent: -9000px;
     width: 40px;
-    @include focus(var(--user-menu-button-color), var(--color-gray-2));
+    @include focus(var(--user-menu-button-color), var(--color-blue));
     @media (hover: hover) {
       &:not([disabled]):hover {
         background-color: var(--user-menu-button-color);
@@ -28,8 +28,7 @@
       }
     }
     &[aria-expanded="true"] {
-      background-color: var(--color-gray-10);
-      border-color: var(--color-blue);
+      border: thin solid var(--color-blue);
       @media (hover: hover) {
         &:hover {
           border-color: var(--color-blue);


### PR DESCRIPTION
* When clicking a link inside of a dropdown menu, a weird focus artifact would show up. It doesn't anymore
* The user menu circle now has a blue line around it whenever hovered, or while it's expanded