### PR TITLE
Fixes project name clipping

### DIFF
--- a/web/src/client/js/components/Navigator/_Navigator.scss
+++ b/web/src/client/js/components/Navigator/_Navigator.scss
@@ -7,6 +7,13 @@
   position: relative;
 
   .btn {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 210px;
+    @include media('>medium') {
+      max-width: 100%;
+    }
     .icon {
       height: 24px;
       width: 24px;
@@ -14,6 +21,9 @@
     .label {
       font-size: 1.7rem;
       font-weight: 500;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
     &[aria-expanded="true"] {
       .icon {


### PR DESCRIPTION
On mobile, a long project name would push out the UserMenu and screw things up. Fixes that.