### PR TITLE
bump account invite token expiration to 14 days

### DIFF
--- a/api/src/coordinators/demoSignup.js
+++ b/api/src/coordinators/demoSignup.js
@@ -70,7 +70,7 @@ async function createUsersAndOrganization(name, users) {
 
   await Promise.all(
     orgUsers.map((user) => {
-      const token = tokenIntegrator.generatePasswordResetToken(user.id, user.resetKey)
+      const token = tokenIntegrator.generateAccountInviteToken(user.id, user.resetKey)
 
       const linkUrl = `${CLIENT_URL}/sign-up/registration/complete?token=${token}`
 

--- a/api/src/integrators/token.js
+++ b/api/src/integrators/token.js
@@ -32,6 +32,20 @@ const generatePasswordResetToken = (id, resetKey) => {
   )
 }
 
+const generateAccountInviteToken = (id, resetKey) => {
+  return jwt.sign(
+    {
+      id,
+      resetKey
+    },
+    tokenSettings.passwordResetTokenSecret,
+    {
+      expiresIn: tokenSettings.accountInviteExpiration,
+      issuer: tokenSettings.issuer
+    }
+  )
+}
+
 const generateProjectToken = (id, secret, orgId) => {
   return jwt.sign(
     {
@@ -48,5 +62,6 @@ const generateProjectToken = (id, secret, orgId) => {
 export default {
   generateToken,
   generatePasswordResetToken,
+  generateAccountInviteToken,
   generateProjectToken
 }

--- a/api/src/libs/tokenSettings.js
+++ b/api/src/libs/tokenSettings.js
@@ -1,8 +1,10 @@
 export default {
   tokenSecret: process.env.JWT_SECRET,
+  // token secret also shared by account invite
   passwordResetTokenSecret: process.env.PASSWORD_RESET_JWT_SECRET,
   issuer: 'bonkeybong',
   audience: 'portway',
   expiration: '7 days',
-  passwordResetExpiration: '1 days'
+  passwordResetExpiration: '1 days',
+  accountInviteExpiration: '14 days'
 }


### PR DESCRIPTION
Now free accounts have 14 days to click the email link before the link expires.