### PR TITLE
re-enabling redis for rate limiting

### DIFF
--- a/api/src/libs/rateLimiter.js
+++ b/api/src/libs/rateLimiter.js
@@ -1,5 +1,5 @@
 import SlidingWindowRateLimiter from 'sliding-window-rate-limiter'
-// import IORedis from 'ioredis'
+import IORedis from 'ioredis'
 /*
 ## check(key, limit)
 const result = await limiter.check(key, limit)
@@ -20,11 +20,10 @@ const options = {
 }
 
 if (process.env.REDIS_URL) {
-  // TODO: fix redis kubernetes issues
   // sliding-window-rate-limiter is supposed to take a url to redis, but
   // it doesn't seem to work. Much safer to just pass an ioredis instance
-  // const redis = new IORedis(process.env.REDIS_URL)
-  // options.redis = redis
+  const redis = new IORedis(process.env.REDIS_URL)
+  options.redis = redis
 }
 
 const limiter = SlidingWindowRateLimiter.createLimiter(options)

--- a/kubernetes/helm/portway/templates/redis-deployment.yaml
+++ b/kubernetes/helm/portway/templates/redis-deployment.yaml
@@ -1,4 +1,3 @@
-# Remove this comment and rename to .yaml to re-enable
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes/helm/portway/values.yaml
+++ b/kubernetes/helm/portway/values.yaml
@@ -14,10 +14,10 @@ redisPort: "6379"
 stripePublishableKey: "pk_test_1pwhBFZzMbjvUlsgn2EjsfWP"
 
 apiImage: bonkeybong/portway_api
-apiTag: "0.12.1"
+apiTag: "0.12.6"
 
 webImage: bonkeybong/portway_web
-webTag: "0.12.1"
+webTag: "0.12.6"
 
 web:
   port: "3000"


### PR DESCRIPTION
well the k8s networking config issue was definitely the issue. Tested this on dev with 2 API instances, both are able to connect to the single redis instance