### PR TITLE
Removing opacity change for disabled document

### DIFF
--- a/web/src/client/js/components/Document/_Document.scss
+++ b/web/src/client/js/components/Document/_Document.scss
@@ -146,7 +146,6 @@
 
     // When publishing a document, disable everything
     &--disabled {
-      opacity: 0.4;
       pointer-events: none;
     }
 


### PR DESCRIPTION
When publishing, or moving fields between documents we had an opacity change on the document. Removed that. 