### PR TITLE
Updating language for expiration in beta email

### DIFF
--- a/api/src/coordinators/email.js
+++ b/api/src/coordinators/email.js
@@ -5,7 +5,7 @@ import ejs from 'ejs'
 import { sendSingleRecipientEmail } from '../integrators/email'
 import BusinessOrganization from '../businesstime/organization'
 import { SUPPORT_EMAIL } from '../constants/email'
-import { accountInviteExpiration } from '../../src/libs/tokenSettings'
+import tokenSettings from '../../src/libs/tokenSettings'
 
 const { CLIENT_URL } = process.env
 
@@ -76,7 +76,7 @@ async function sendPasswordResetEmail(resetLink, email) {
 
 async function sendFreeAccountInvite(linkUrl, email) {
   const subject = 'Welcome to Portway!'
-  const expirePeriod = accountInviteExpiration // 14 days
+  const expirePeriod = tokenSettings.accountInviteExpiration // 14 days
   const textBody = `Welcome to Portway! We'd like to offer you a free account you can claim here:\n\n${linkUrl}\n\nThis invite expires in ${expirePeriod}.`
   const htmlBody = await EJS_TEMPLATE_FUNCTIONS[EMAIL_TEMPLATES.FREE_INVITE]({ linkUrl, expirePeriod })
 

--- a/api/src/coordinators/email.js
+++ b/api/src/coordinators/email.js
@@ -5,6 +5,7 @@ import ejs from 'ejs'
 import { sendSingleRecipientEmail } from '../integrators/email'
 import BusinessOrganization from '../businesstime/organization'
 import { SUPPORT_EMAIL } from '../constants/email'
+import { accountInviteExpiration } from '../../src/libs/tokenSettings'
 
 const { CLIENT_URL } = process.env
 
@@ -75,8 +76,9 @@ async function sendPasswordResetEmail(resetLink, email) {
 
 async function sendFreeAccountInvite(linkUrl, email) {
   const subject = 'Welcome to Portway!'
-  const textBody = `Welcome to Portway! We'd like to offer you a free account you can claim here:\n\n${linkUrl}`
-  const htmlBody = await EJS_TEMPLATE_FUNCTIONS[EMAIL_TEMPLATES.FREE_INVITE]({ linkUrl })
+  const expirePeriod = accountInviteExpiration // 14 days
+  const textBody = `Welcome to Portway! We'd like to offer you a free account you can claim here:\n\n${linkUrl}\n\nThis invite expires in ${expirePeriod}.`
+  const htmlBody = await EJS_TEMPLATE_FUNCTIONS[EMAIL_TEMPLATES.FREE_INVITE]({ linkUrl, expirePeriod })
 
   return sendSingleRecipientEmail({ address: email, htmlBody, textBody, subject })
 }

--- a/api/src/templates/email/ejs/free-account-invite.html
+++ b/api/src/templates/email/ejs/free-account-invite.html
@@ -296,6 +296,7 @@
                     <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div style="font-family:Domine;font-size:13px;line-height:1;text-align:center;color:#333333;">
                         <p>We’d love for you to check out Portway. Here’s an invite for a free, Teams account with a limit of five team members.</p>
+                        <p>This invite will expire in <%= expirePeriod %>. If you’ve missed your opportunity, <a href="mailto:support@portway.app" style="color: #333;">email support</a>.
                       </div>
                     </td>
                   </tr>

--- a/api/src/templates/email/mjml/free-account-invite.mjml
+++ b/api/src/templates/email/mjml/free-account-invite.mjml
@@ -70,6 +70,7 @@
       <mj-column>
         <mj-text align="center">
           <p>We’d love for you to check out Portway. Here’s an invite for a free, Teams account with a limit of five team members.</p>
+          <p>This invite will expire in <%= expirePeriod %>. If you’ve missed your opportunity, <a href="mailto:support@portway.app" style="color: #333;">email support</a>.
         </mj-text>
         <mj-button href="<%= linkUrl %>">Set up your free account</mj-button>
         <mj-spacer height="50px" />


### PR DESCRIPTION
Uses the `accountInviteExpiration` value from tokenSettings. Not sure if that's cool?