### PR TITLE
Hiding fullscreen button for mobile safari

### DIFF
--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link, useParams } from 'react-router-dom'
+import cx from 'classnames'
 
 import useDataService from 'Hooks/useDataService'
 import dataMapper from 'Libs/dataMapper'
@@ -23,6 +24,7 @@ const DocumentComponent = ({
   toggleFullScreenHandler,
 }) => {
   const { projectId } = useParams()
+  const documentRef = useRef()
   const titleRef = useRef()
   const { data: userProjectAssignments = {}, loading: assignmentLoading } = useDataService(dataMapper.users.currentUserProjectAssignments())
 
@@ -46,6 +48,7 @@ const DocumentComponent = ({
   const projectAssignment = userProjectAssignments[Number(projectId)]
   const readOnlyRoleIds = [PROJECT_ROLE_IDS.READER]
   const mobileView = window.matchMedia(MOBILE_MATCH_SIZE).matches
+  const supportsFullScreen = documentRef.current && documentRef.current.requestFullscreen
 
   let documentReadOnlyMode
   // False because null / true == loading
@@ -58,7 +61,7 @@ const DocumentComponent = ({
   })
 
   return (
-    <div className="document" key={docKey}>
+    <div className="document" key={docKey} ref={documentRef}>
       <ValidationContainer resource="document" value="name" />
       <header className="document__header">
         {mobileView &&
@@ -66,7 +69,7 @@ const DocumentComponent = ({
           <ArrowIcon direction="left" width="12" height="12" />
         </Link>
         }
-        {!mobileView &&
+        {!mobileView && supportsFullScreen &&
         <button
           aria-label="Expand the editor to full screen"
           className="btn btn--blank btn--with-circular-icon document__button-expand"

--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link, useParams } from 'react-router-dom'
-import cx from 'classnames'
 
 import useDataService from 'Hooks/useDataService'
 import dataMapper from 'Libs/dataMapper'
@@ -48,7 +47,7 @@ const DocumentComponent = ({
   const projectAssignment = userProjectAssignments[Number(projectId)]
   const readOnlyRoleIds = [PROJECT_ROLE_IDS.READER]
   const mobileView = window.matchMedia(MOBILE_MATCH_SIZE).matches
-  const supportsFullScreen = documentRef.current && documentRef.current.requestFullscreen
+  const supportsFullScreen = documentRef.current && (documentRef.current.requestFullscreen || documentRef.current.webkitRequestFullscreen)
 
   let documentReadOnlyMode
   // False because null / true == loading

--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -48,6 +48,7 @@ const DocumentComponent = ({
   const readOnlyRoleIds = [PROJECT_ROLE_IDS.READER]
   const mobileView = window.matchMedia(MOBILE_MATCH_SIZE).matches
   const supportsFullScreen = documentRef.current && (documentRef.current.requestFullscreen || documentRef.current.webkitRequestFullscreen)
+  const isLikelyAniPad = 'TouchEvent' in window && navigator.platform === 'MacIntel'
 
   let documentReadOnlyMode
   // False because null / true == loading
@@ -68,7 +69,7 @@ const DocumentComponent = ({
           <ArrowIcon direction="left" width="12" height="12" />
         </Link>
         }
-        {!mobileView && supportsFullScreen &&
+        {!mobileView && !isLikelyAniPad && supportsFullScreen &&
         <button
           aria-label="Expand the editor to full screen"
           className="btn btn--blank btn--with-circular-icon document__button-expand"

--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -48,7 +48,7 @@ const DocumentComponent = ({
   const readOnlyRoleIds = [PROJECT_ROLE_IDS.READER]
   const mobileView = window.matchMedia(MOBILE_MATCH_SIZE).matches
   const supportsFullScreen = documentRef.current && (documentRef.current.requestFullscreen || documentRef.current.webkitRequestFullscreen)
-  const isLikelyAniPad = 'TouchEvent' in window && navigator.platform === 'MacIntel'
+  const isLikelyAniPad = 'ontouchstart' in window && navigator.platform === 'MacIntel'
 
   let documentReadOnlyMode
   // False because null / true == loading

--- a/web/src/client/js/components/Document/_Document.scss
+++ b/web/src/client/js/components/Document/_Document.scss
@@ -49,9 +49,9 @@
   }
 
   &__button-expand {
-    padding: 0 1.5rem;
+    padding: 0 0 0 1.5rem;
     @include media('>medium') {
-      padding: 0 1.9rem;
+      padding: 0 0 0 1.9rem;
     }
   }
 
@@ -60,6 +60,7 @@
     display: flex;
     height: calc(var(--header-height) - 2);
     flex: 1;
+    padding: 0 1.5rem;
   }
 
   &__title {


### PR DESCRIPTION
Full screen mode for dom elements is disabled in iOS < 13.2. We should hide the full screen button if the browser doesn't support fullscreen API, or if the browser is an iPad.

~iPadOS however, DOES support fullscreen, except you can't actually do anything in it (typing is disabled). Once you tap in the window in fullscreen, it collapses back. There's no way to hide the button on iPadOS because there's no way to detect proper functionality.~