### PR TITLE
Fixed header title when navigating back to projects list

### DIFF
--- a/web/src/client/js/components/Header/HeaderComponent.js
+++ b/web/src/client/js/components/Header/HeaderComponent.js
@@ -9,6 +9,7 @@ import {
   ORGANIZATION_ROLE_IDS,
   PATH_ADMIN,
   PATH_BILLING,
+  PATH_HELP,
   PATH_PROJECTS,
   PATH_SETTINGS,
   ORG_SUBSCRIPTION_STATUS,
@@ -34,6 +35,22 @@ const HeaderComponent = ({ brand, isFullScreen, loading, section, subscriptionSt
     'pill--red': LOCKED_ACCOUNT_STATUSES.includes(subscriptionStatus),
     'pill--gray': grayPillStatuses.includes(subscriptionStatus)
   })
+
+  function getHeaderTitle(section) {
+    const sectionPath = `/${section}`
+    switch (sectionPath) {
+      case PATH_SETTINGS:
+        return <>My settings</>
+      case PATH_ADMIN:
+        return <>Administer Organization</>
+      case PATH_HELP:
+        return <>Help</>
+      default:
+        if (!loading) return <NavigatorContainer />
+        return ''
+    }
+  }
+
   if (!isFullScreen) {
     return (
       <>
@@ -45,9 +62,7 @@ const HeaderComponent = ({ brand, isFullScreen, loading, section, subscriptionSt
               </Link>
             </div>
             <div className="navbar__content">
-              {`/${section}` === PATH_SETTINGS && (<>My Settings</>)}
-              {`/${section}` === PATH_ADMIN && (<>Administer Organization</>)}
-              {`/${section}` !== PATH_ADMIN && `/${section}` !== PATH_SETTINGS && !loading && <NavigatorContainer />}
+              {getHeaderTitle(section)}
             </div>
             <div className="navbar__misc">
               {!window.matchMedia(MOBILE_MATCH_SIZE).matches &&

--- a/web/src/client/js/components/Navigator/NavigatorContainer.js
+++ b/web/src/client/js/components/Navigator/NavigatorContainer.js
@@ -9,6 +9,7 @@ import {
   ORGANIZATION_ROLE_IDS,
   ORGANIZATION_SETTINGS,
   PATH_PROJECT,
+  PATH_PROJECTS,
   PATH_PROJECT_CREATE,
   PRODUCT_NAME,
   PROJECT_ROLE_IDS
@@ -34,6 +35,13 @@ const NavigatorContainer = ({ history, location }) => {
   const { data: project } = useDataService(
     currentResource('project', location.pathname), [location.pathname]
   )
+
+  let title = ''
+  if (location.pathname === PATH_PROJECTS) {
+    title = 'Projects'
+  } else {
+    title = project ? project.name : 'Projects'
+  }
 
   const [expanded, setExpanded] = useState(false)
   const selectRef = useRef()
@@ -117,7 +125,7 @@ const NavigatorContainer = ({ history, location }) => {
           ref={anchorRef}
         >
           <CaretIcon />
-          <span className="label">{project ? project.name : 'Projects'}</span>
+          <span className="label">{title}</span>
         </button>
         <Popper anchorRef={anchorRef} autoCollapse={collapseCallback} open={expanded} width="300">
           <Menu anchorRef={anchorRef}>

--- a/web/src/client/js/components/Navigator/NavigatorContainer.js
+++ b/web/src/client/js/components/Navigator/NavigatorContainer.js
@@ -36,11 +36,9 @@ const NavigatorContainer = ({ history, location }) => {
     currentResource('project', location.pathname), [location.pathname]
   )
 
-  let title = ''
-  if (location.pathname === PATH_PROJECTS) {
-    title = 'Projects'
-  } else {
-    title = project ? project.name : 'Projects'
+  let title = 'Projects'
+  if (location.pathname !== PATH_PROJECTS && project) {
+    title = project.name
   }
 
   const [expanded, setExpanded] = useState(false)

--- a/web/src/client/js/libs/currentResource.js
+++ b/web/src/client/js/libs/currentResource.js
@@ -6,6 +6,8 @@
 import { matchPath } from 'react-router-dom'
 import dataMapper from './dataMapper'
 
+import { PATH_PROJECTS } from 'Shared/constants'
+
 function returnNull() {
   return {
     fetchAction: () => null,
@@ -28,9 +30,10 @@ const currentResource = (resourceName, path) => {
     case 'project':
       // Specifically look at project here, as we may be looking at documents
       const projectPathArray = path.split('/')
+      const projectsPath = PATH_PROJECTS.split('/')[1]
 
       // We're back on the projects list
-      if (projectPathArray[1] === 'projects') {
+      if (projectPathArray[1] === projectsPath) {
         returnValue = returnNull()
         break
       }

--- a/web/src/client/js/libs/currentResource.js
+++ b/web/src/client/js/libs/currentResource.js
@@ -28,7 +28,15 @@ const currentResource = (resourceName, path) => {
     case 'project':
       // Specifically look at project here, as we may be looking at documents
       const projectPathArray = path.split('/')
+
+      // We're back on the projects list
+      if (projectPathArray[1] === 'projects') {
+        returnValue = returnNull()
+        break
+      }
+
       const projectPath = `/${projectPathArray[1]}/${projectPathArray[2]}`
+
       if (projectPathArray[2] === 'create') {
         returnValue = returnNull()
         break


### PR DESCRIPTION
If you went to a project, and then back to the project list, the header never changed back to "Projects"