### PR TITLE
Added confirmation theming

### DIFF
--- a/web/src/client/js/actions/index.js
+++ b/web/src/client/js/actions/index.js
@@ -288,7 +288,7 @@ export const UI = {
   createTokenMode: makeActionCreator(ActionTypes.UI_CREATE_TOKEN_MODE, 'value'),
   createUserMode: makeActionCreator(ActionTypes.UI_CREATE_USER_MODE, 'value'),
   documentCreate: makeActionCreator(ActionTypes.UI_DOCUMENT_CREATE, 'value'),
-  initiateConfirm: makeActionCreator(ActionTypes.UI_INITIATE_CONFIRMATION, 'message', 'cancelAction', 'confirmedAction', 'confirmedLabel', 'confirmedText'),
+  initiateConfirm: makeActionCreator(ActionTypes.UI_INITIATE_CONFIRMATION, 'message', 'options'),
   toggleDocumentMode: makeActionCreator(ActionTypes.UI_DOCUMENT_MODE, 'value'),
   toggleFullScreen: makeActionCreator(ActionTypes.UI_DOCUMENT_FULL_SCREEN, 'value'),
   toggleStripeForm: makeActionCreator(ActionTypes.UI_TOGGLE_STRIPE_FORM, 'value'),

--- a/web/src/client/js/actions/ui.js
+++ b/web/src/client/js/actions/ui.js
@@ -43,9 +43,10 @@ export const uiToggleStripeForm = (value) => {
 /**
  * Confirmation system
  */
-export const uiConfirm = ({ message, cancelAction, confirmedAction, confirmedLabel, confirmedText }) => {
+export const uiConfirm = ({ message, options }) => {
+  // Options: cancelAction, confirmedAction, confirmedLabel, confirmedText, theme
   return async (dispatch) => {
-    dispatch(UI.initiateConfirm(message, cancelAction, confirmedAction, confirmedLabel, confirmedText))
+    dispatch(UI.initiateConfirm(message, options))
   }
 }
 export const uiConfirmCancel = () => {

--- a/web/src/client/js/components/Admin/AdminCancelAccount/AdminCancelAccountContainer.js
+++ b/web/src/client/js/components/Admin/AdminCancelAccount/AdminCancelAccountContainer.js
@@ -49,12 +49,13 @@ const AdminCancelAccountContainer = ({ deleteOrganization, uiConfirm }) => {
 
   function deleteAccountHander() {
     const message = TRIALING_STATUSES.includes(currentOrg.subscriptionStatus) ? trialingMessage : paidCustomerMessage
-    const confirmedAction = () => {
-      deleteOrganization(currentOrg.id)
+    const options = {
+      confirmedAction: () => { deleteOrganization(currentOrg.id) },
+      confirmedLabel: 'Yes, cancel my account',
+      confirmedText: currentOrg.name,
+      theme: 'danger'
     }
-    const confirmedLabel = 'Yes, cancel my account'
-    const confirmedText = currentOrg.name
-    uiConfirm({ message, confirmedAction, confirmedLabel, confirmedText })
+    uiConfirm({ message, options })
   }
 
   return (

--- a/web/src/client/js/components/Admin/AdminPlanSelector/AdminPlanSelectorContainer.js
+++ b/web/src/client/js/components/Admin/AdminPlanSelector/AdminPlanSelectorContainer.js
@@ -20,11 +20,11 @@ const AdminPlanSelectorContainer = ({ updateOrganizationPlan, uiConfirm }) => {
     const message = (
       <p>Change your plan to a {planTitle}? <b>You will be charged {PRICING[val]}</b></p>
     )
-    const confirmedAction = () => {
-      updateOrganizationPlan(planSelectorId, currentOrg.id, { plan: val })
+    const options = {
+      confirmedAction: () => { updateOrganizationPlan(planSelectorId, currentOrg.id, { plan: val }) },
+      confirmedLabel: 'Yes, I understand'
     }
-    const confirmedLabel = 'Yes, I understand'
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    uiConfirm({ message, options })
   }
 
   return (

--- a/web/src/client/js/components/Admin/AdminUserView/AdminUserViewContainer.js
+++ b/web/src/client/js/components/Admin/AdminUserView/AdminUserViewContainer.js
@@ -30,9 +30,12 @@ const AdminUserViewContainer = ({ match, removeProjectAssignee, updateProjectAss
 
   function removeProjectHandler(projectId, assignmentId) {
     const message = <span>Remove <span className="highlight">{userFromRoute.name}</span> from this project?</span>
-    const confirmedAction = () => { return removeProjectAssignee(projectId, userFromRoute.id, assignmentId) }
-    const confirmedLabel = `Yes`
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedAction: () => { return removeProjectAssignee(projectId, userFromRoute.id, assignmentId) },
+      confirmedLabel: `Yes`,
+      theme: 'danger',
+    }
+    uiConfirm({ message, options })
   }
 
   return (

--- a/web/src/client/js/components/Admin/AdminUsers/AdminUsersContainer.js
+++ b/web/src/client/js/components/Admin/AdminUsers/AdminUsersContainer.js
@@ -66,9 +66,12 @@ const AdminUsersContainer = ({
     const message = (
       <span>Delete <span className="highlight danger">{user.name}</span>?</span>
     )
-    const confirmedAction = () => { removeUser(userId) }
-    const confirmedLabel = 'Yes, delete this user'
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedAction: () => { removeUser(userId) },
+      confirmedLabel: 'Yes, delete this user',
+      theme: 'danger'
+    }
+    uiConfirm({ message, options })
   }
 
   function sortUsersHandler(selectedSortProperty) {

--- a/web/src/client/js/components/Confirmation/ConfirmationComponent.js
+++ b/web/src/client/js/components/Confirmation/ConfirmationComponent.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import useClickOutside from 'Hooks/useClickOutside'
 import FormField from 'Components/Form/FormField'
@@ -10,7 +11,8 @@ const ConfirmationComponent = ({
   confirmedAction,
   confirmedLabel,
   confirmedText,
-  message
+  message,
+  theme
 }) => {
   const [typedMessage, setTypedMessage] = useState()
   const confirmationRef = useRef()
@@ -34,8 +36,21 @@ const ConfirmationComponent = ({
     }
   })
 
+  const confirmationClasses = cx({
+    'confirmation': true,
+    'confirmation--danger': theme === 'danger',
+    'confirmation--success': theme === 'success',
+  })
+
+  const confirmationButtonClasses = cx({
+    'btn': true,
+    'btn--white': theme === 'danger',
+    'btn--danger': theme === 'danger',
+    'confirmation__confirm': true,
+  })
+
   return (
-    <div className="confirmation" role="alert">
+    <div className={confirmationClasses} role="alert">
       <div className="confirmation__dialog" ref={confirmationRef}>
         <div className="confirmation__message">
           {message}
@@ -57,7 +72,7 @@ const ConfirmationComponent = ({
           <button className="btn btn--white confirmation__cancel" onClick={cancelAction}>Cancel</button>
           }
           <button
-            className="btn btn--white btn--danger confirmation__confirm"
+            className={confirmationButtonClasses}
             disabled={confirmedText && !confirmationTextMatch()}
             onClick={confirmedAction}
           >
@@ -75,6 +90,7 @@ ConfirmationComponent.propTypes = {
   confirmedLabel: PropTypes.string,
   confirmedText: PropTypes.string,
   message: PropTypes.element.isRequired,
+  theme: PropTypes.string,
 }
 
 ConfirmationComponent.defaultProps = {

--- a/web/src/client/js/components/Confirmation/ConfirmationContainer.js
+++ b/web/src/client/js/components/Confirmation/ConfirmationContainer.js
@@ -7,21 +7,29 @@ import ConfirmationComponent from './ConfirmationComponent'
 
 const ConfirmationContainer = ({ confirmation, uiConfirmCancel, uiConfirmComplete }) => {
   if (confirmation.confirming) {
+    const {
+      cancelAction,
+      confirmedAction,
+      confirmedLabel,
+      confirmedText,
+      theme
+    } = confirmation.options
     return (
       <ConfirmationComponent
         message={confirmation.message}
         cancelAction={() => {
-          if (confirmation.cancelAction) {
-            confirmation.cancelAction()
+          if (cancelAction) {
+            cancelAction()
           }
           uiConfirmCancel()
         }}
         confirmedAction={() => {
-          confirmation.confirmedAction()
+          confirmedAction()
           uiConfirmComplete()
         }}
-        confirmedLabel={confirmation.confirmedLabel}
-        confirmedText={confirmation.confirmedText} />
+        confirmedLabel={confirmedLabel}
+        confirmedText={confirmedText}
+        theme={theme} />
     )
   } else {
     return null

--- a/web/src/client/js/components/Confirmation/_Confirmation.scss
+++ b/web/src/client/js/components/Confirmation/_Confirmation.scss
@@ -30,7 +30,8 @@
     border: thin solid var(--confirmation-border, gray);
     border-radius: var(--border-radius, 8px);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 1px 2px rgba(0, 0, 0, 0.02);
-    padding: 24px;
+    max-width: 70rem;
+    padding: 2.4rem;
     width: 75vw;
     @include media('>medium') {
       width: 50vw;

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -126,9 +126,12 @@ const DocumentFieldsContainer = ({
       }
 
       const message = <span>Are you sure you want to delete this {type}?</span>
-      const confirmedLabel = 'Yes, delete it.'
-      const confirmedAction = () => { removeField(projectId, documentId, fieldId) }
-      uiConfirm({ message, confirmedAction, confirmedLabel })
+      const options = {
+        confirmedAction: () => { removeField(projectId, documentId, fieldId) },
+        confirmedLabel: 'Yes, delete it.',
+        theme: 'danger'
+      }
+      uiConfirm({ message, options })
     }
   }
 

--- a/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
+++ b/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
@@ -42,18 +42,23 @@ const DocumentToolbarContainer = ({
         <p>{strings.PUBLISH_CONFIRMATION_DESCRIPTION}</p>
       </>
     )
-    const confirmedLabel = strings.PUBLISH_CONFIRMATION_LABEL
-    const confirmedAction = () => { publishDocument(document.id) }
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedLabel: strings.PUBLISH_CONFIRMATION_LABEL,
+      confirmedAction: () => { publishDocument(document.id) }
+    }
+    uiConfirm({ message, options })
   }
 
   function removeDocumentHandler() {
     const message = (
       <span>{strings.DELETE_CONFIRMATION_TITLE_PREFIX} <span className="highlight">{document.name}</span> {strings.DELETE_CONFIRMATION_TITLE_SUFFIX}</span>
     )
-    const confirmedLabel = strings.DELETE_CONFIRMATION_LABEL
-    const confirmedAction = () => { deleteDocument(projectId, document.id, history) }
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedLabel: strings.DELETE_CONFIRMATION_LABEL,
+      confirmedAction: () => { deleteDocument(projectId, document.id, history) },
+      theme: 'danger'
+    }
+    uiConfirm({ message, options })
   }
 
   function unpublishDocumentHandler() {
@@ -63,9 +68,12 @@ const DocumentToolbarContainer = ({
         <p>{strings.UNPUBLISH_CONFIRMATION_DESCRIPTION}</p>
       </>
     )
-    const confirmedLabel = strings.UNPUBLISH_CONFIRMATION_LABEL
-    const confirmedAction = () => { unpublishDocument(document.id) }
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedLabel: strings.UNPUBLISH_CONFIRMATION_LABEL,
+      confirmedAction: () => { unpublishDocument(document.id) },
+      theme: 'danger'
+    }
+    uiConfirm({ message, options })
   }
 
   return (

--- a/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
+++ b/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
@@ -36,7 +36,15 @@ const DocumentToolbarContainer = ({
   }
 
   function publishDocumentHandler() {
-    publishDocument(document.id)
+    const message = (
+      <>
+        <p><b>{strings.PUBLISH_CONFIRMATION_TITLE} “<span className="highlight">{document.name}</span>”?</b></p>
+        <p>{strings.PUBLISH_CONFIRMATION_DESCRIPTION}</p>
+      </>
+    )
+    const confirmedLabel = strings.PUBLISH_CONFIRMATION_LABEL
+    const confirmedAction = () => { publishDocument(document.id) }
+    uiConfirm({ message, confirmedAction, confirmedLabel })
   }
 
   function removeDocumentHandler() {

--- a/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
@@ -113,18 +113,24 @@ const DocumentsListContainer = ({
         <p>{strings.UNPUBLISH_CONFIRMATION_DESCRIPTION}</p>
       </>
     )
-    const confirmedLabel = strings.UNPUBLISH_CONFIRMATION_LABEL
-    const confirmedAction = () => { unpublishDocument(document.id) }
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedAction: () => { unpublishDocument(document.id) },
+      confirmedLabel: strings.UNPUBLISH_CONFIRMATION_LABEL,
+      theme: 'danger'
+    }
+    uiConfirm({ message, options })
   }
 
   function removeDocumentHandler(document) {
     const message = (
       <span>{strings.DELETE_CONFIRMATION_TITLE_PREFIX} <span className="highlight">{document.name}</span> {strings.DELETE_CONFIRMATION_TITLE_SUFFIX}</span>
     )
-    const confirmedLabel = strings.DELETE_CONFIRMATION_LABEL
-    const confirmedAction = () => { deleteDocument(document.projectId, document.id, history) }
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedAction: () => { deleteDocument(document.projectId, document.id, history) },
+      confirmedLabel: strings.DELETE_CONFIRMATION_LABEL,
+      theme: 'danger'
+    }
+    uiConfirm({ message, options })
   }
 
   function clearSearchHandler() {

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsInfo/ProjectSettingsInfoContainer.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsInfo/ProjectSettingsInfoContainer.js
@@ -32,12 +32,13 @@ const ProjectSettingsInfoContainer = ({ errors, removeProject, uiConfirm, update
         <p>{strings.DELETE_PROJECT_DESCRIPTION}</p>
       </>
     )
-    const confirmedAction = () => {
-      removeProject(project.id, history)
+    const options = {
+      confirmedAction: () => { removeProject(project.id, history) },
+      confirmedLabel: strings.DELETE_PROJECT_BUTTON_LABEL,
+      confirmedText: project.name,
+      theme: 'danger'
     }
-    const confirmedLabel = strings.DELETE_PROJECT_BUTTON_LABEL
-    const confirmedText = project.name
-    uiConfirm({ message, confirmedAction, confirmedLabel, confirmedText })
+    uiConfirm({ message, options })
   }
 
   const debouncedUpdateHandler = (body) => {

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsContainer.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTeams/ProjectSettingsTeamsContainer.js
@@ -67,9 +67,12 @@ const ProjectSettingsTeamContainer = ({ location }) => {
   function removeAssignmentHandler(userId, assignmentId) {
     const name = projectUsers[userId].name
     const message = <span>Remove <span className="highlight">{name}</span> from this project?</span>
-    const confirmedAction = () => { Store.dispatch(removeProjectAssignee(projectId, userId, assignmentId)) }
-    const confirmedLabel = `Yes, remove ${name}`
-    Store.dispatch(uiConfirm({ message, confirmedAction, confirmedLabel }))
+    const options = {
+      confirmedAction: () => { Store.dispatch(removeProjectAssignee(projectId, userId, assignmentId)) },
+      confirmedLabel: `Yes, remove ${name}`,
+      theme: 'danger'
+    }
+    Store.dispatch(uiConfirm({ message, options }))
   }
 
   function userSearchHandler(partialNameString) {

--- a/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokensContainer.js
+++ b/web/src/client/js/components/ProjectSettings/ProjectSettingsTokens/ProjectSettingsTokensContainer.js
@@ -40,9 +40,12 @@ const ProjectSettingsTokensContainer = ({ createProjectToken, creating, location
     const message = (
       <span>Deleting this token will prevent access to any application using it. Are you sure?</span>
     )
-    const confirmedLabel = `Yes, delete this token`
-    const confirmedAction = () => { removeProjectToken(projectId, tokenId) }
-    uiConfirm({ message, confirmedAction, confirmedLabel })
+    const options = {
+      confirmedLabel: `Yes, delete this token`,
+      confirmedAction: () => { removeProjectToken(projectId, tokenId) },
+      theme: 'danger'
+    }
+    uiConfirm({ message, options })
   }
 
   function setCreateMode(value) {

--- a/web/src/client/js/components/ProjectsList/ProjectsListContainer.js
+++ b/web/src/client/js/components/ProjectsList/ProjectsListContainer.js
@@ -21,12 +21,13 @@ const ProjectsListContainer = ({ history, removeProject, uiConfirm }) => {
         <p>{strings.DELETE_PROJECT_DESCRIPTION}</p>
       </>
     )
-    const confirmedAction = () => {
-      removeProject(projectId, history)
+    const options = {
+      confirmedAction: () => { removeProject(projectId, history) },
+      confirmedLabel: strings.DELETE_PROJECT_BUTTON_LABEL,
+      confirmedText: projects[projectId].name,
+      theme: 'danger',
     }
-    const confirmedLabel = strings.DELETE_PROJECT_BUTTON_LABEL
-    const confirmedText = projects[projectId].name
-    uiConfirm({ message, confirmedAction, confirmedLabel, confirmedText })
+    uiConfirm({ message, options })
   }
 
   return (

--- a/web/src/client/js/loc/strings.js
+++ b/web/src/client/js/loc/strings.js
@@ -5,6 +5,11 @@ module.exports = {
   DELETE_PROJECT_DESCRIPTION: 'This will remove all of the documents, assets, and other media related to this project.',
   DELETE_PROJECT_BUTTON_LABEL: 'Yes, delete this project',
   // Document --------------------------------------------------------------------------------------
+  // Document Publish
+  PUBLISH_CONFIRMATION_TITLE: 'Publish ',
+  PUBLISH_CONFIRMATION_DESCRIPTION: 'Publishing these changes will make them live in the API.',
+  PUBLISH_CONFIRMATION_LABEL: 'Yes, publish this document',
+  PUBLISH_BUTTON_LABEL: 'Publish document',
   // Document Unpublish
   UNPUBLISH_CONFIRMATION_TITLE: 'Unpublish the document',
   UNPUBLISH_CONFIRMATION_DESCRIPTION: 'If you are using this document in a live application, it will be removed.',

--- a/web/src/client/js/reducers/ui.js
+++ b/web/src/client/js/reducers/ui.js
@@ -5,10 +5,13 @@ const initialState = {
   confirmation: {
     confirming: false,
     message: '',
-    cancelAction: null,
-    confirmedAction: null,
-    confirmedLabel: '',
-    confirmedText: null,
+    options: {
+      cancelAction: null,
+      confirmedAction: null,
+      confirmedLabel: '',
+      confirmedText: null,
+      theme: null,
+    },
   },
   document: {
     documentMode: DOCUMENT_MODE.NORMAL,
@@ -217,10 +220,10 @@ export const ui = (state = initialState, action) => {
           ...state.confirmation,
           confirming: true,
           message: action.message,
-          cancelAction: action.cancelAction,
-          confirmedAction: action.confirmedAction,
-          confirmedLabel: action.confirmedLabel,
-          confirmedText: action.confirmedText,
+          options: {
+            ...state.confirmation.options,
+            ...action.options
+          }
         }
       }
     }
@@ -232,12 +235,10 @@ export const ui = (state = initialState, action) => {
       }
     }
     case ActionTypes.UI_CANCEL_CONFIRMATION: {
+      const confirmation = initialState.confirmation
       return {
         ...state,
-        confirmation: {
-          ...state.confirmation,
-          confirming: false
-        }
+        confirmation
       }
     }
 


### PR DESCRIPTION
All confirmations were getting red primary buttons. This gives us the ability to theme that button, depending on the action. Actions like Publishing and Upgrading plans shouldn't be "red" since that's more of a danger color. 