### PR TITLE
fix require path to work on dev and prod

### DIFF
--- a/api/src/coordinators/email.js
+++ b/api/src/coordinators/email.js
@@ -5,7 +5,7 @@ import ejs from 'ejs'
 import { sendSingleRecipientEmail } from '../integrators/email'
 import BusinessOrganization from '../businesstime/organization'
 import { SUPPORT_EMAIL } from '../constants/email'
-import tokenSettings from '../../src/libs/tokenSettings'
+import tokenSettings from '../libs/tokenSettings'
 
 const { CLIENT_URL } = process.env
 


### PR DESCRIPTION
The require path was going out too many directories and had `src` hard-coded when the prod build puts files in `dist`. Thus an error when trying to start the API.