### PR TITLE
createdBy when project is added

### DIFF
--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -6,7 +6,7 @@ const PROJECT_DOCUMENT_PUBLIC_FIELDS = ['name', 'publishedVersionId', 'projectId
 
 const DOCUMENT_PUBLIC_FIELDS = PROJECT_DOCUMENT_PUBLIC_FIELDS.concat(['fields'])
 
-const PROJECT_PUBLIC_FIELDS = ['name', 'description', 'accessLevel'].concat(globalPublicFields)
+const PROJECT_PUBLIC_FIELDS = ['name', 'description', 'accessLevel', 'createdBy'].concat(globalPublicFields)
 
 const FIELD_PUBLIC_FIELDS = [
   'name',

--- a/api/src/controllers/projects.js
+++ b/api/src/controllers/projects.js
@@ -75,6 +75,8 @@ const getProject = async function(req, res, next) {
 const addProject = async function(req, res, next) {
   const { body } = req
   body.orgId = req.requestorInfo.orgId
+  body.createdBy = req.requestorInfo.requestorId
+
   try {
     const project = await projectCoordinator.createProject(
       body,

--- a/api/src/db/migrations/20200304014200-add-created-by-to-project.js
+++ b/api/src/db/migrations/20200304014200-add-created-by-to-project.js
@@ -1,0 +1,9 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Projects', 'createdBy', Sequelize.INTEGER)
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Projects', 'createdBy')
+  }
+}

--- a/api/src/db/models/project.js
+++ b/api/src/db/models/project.js
@@ -8,7 +8,8 @@ export default function(sequelize, DataTypes) {
       accessLevel: {
         type: DataTypes.STRING,
         defaultValue: null
-      }
+      },
+      createdBy: DataTypes.INTEGER
     },
     {
       paranoid: true


### PR DESCRIPTION
add createdBy to projects from requestor user id, this is an optional field and not directly tied to user model by foreign key. This way, these could be null, or tied to a user that no longer exists, but I don't think we necessarily care about that.