### PR TITLE
FieldText: Hide textareas and fix autofocus of new fields

### DIFF
--- a/web/src/client/js/actions/field.js
+++ b/web/src/client/js/actions/field.js
@@ -20,9 +20,12 @@ export const createField = (projectId, documentId, fieldType, body) => {
       dispatch(Notifications.create(data.error, NOTIFICATION_TYPES.ERROR, NOTIFICATION_RESOURCE.USER, status))
       return
     }
-    validationCodes.includes(status) ?
-      dispatch(Validation.create('field', data, status)) :
+    if (validationCodes.includes(status)) {
+      dispatch(Validation.create('field', data, status))
+    } else {
       dispatch(Fields.receiveOneCreated(projectId, documentId, data))
+      dispatch(Fields.focusFieldWithId(data.id, data.type))
+    }
   }
 }
 

--- a/web/src/client/js/actions/index.js
+++ b/web/src/client/js/actions/index.js
@@ -64,6 +64,7 @@ export const ActionTypes = {
   REMOVE_FIELD: 'REMOVE_FIELD',
   FOCUS_FIELD: 'FOCUS_FIELD',
   BLUR_FIELD: 'BLUR_FIELD',
+  FOCUS_FIELD_WITH_ID: 'FOCUS_FIELD_WITH_ID',
   // Notifications
   CREATE_NOTIFICATION: 'CREATE_NOTIFICATION',
   DISMISS_NOTIFICATION: 'DISMISS_NOTIFICATION',
@@ -221,9 +222,11 @@ export const Fields = {
   // Remove
   initiateRemove: makeActionCreator(ActionTypes.INITIATE_FIELD_REMOVE),
   removeOne: makeActionCreator(ActionTypes.REMOVE_FIELD, 'projectId', 'documentId', 'fieldId'),
-  // Blur / Focus
+  // Blur / Focus events
   blurField: makeActionCreator(ActionTypes.BLUR_FIELD, 'fieldId', 'fieldType', 'fieldData'),
   focusField: makeActionCreator(ActionTypes.FOCUS_FIELD, 'fieldId', 'fieldType', 'fieldData'),
+  // Focus action
+  focusFieldWithId: makeActionCreator(ActionTypes.FOCUS_FIELD_WITH_ID, 'id', 'type'),
 }
 
 export const Notifications = {

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
@@ -50,7 +50,7 @@ const DocumentFieldsComponent = ({
       case FIELD_TYPES.TEXT:
         fieldTypeComponent = (
           <FieldTextComponent
-            autoFocusElement={hasOnlyOneTextField}
+            autoFocusElement={hasOnlyOneTextField || createdFieldId === field.id}
             field={field}
             onBlur={fieldBlurHandler}
             onChange={fieldChangeHandler}

--- a/web/src/client/js/components/FieldText/FieldText.scss
+++ b/web/src/client/js/components/FieldText/FieldText.scss
@@ -6,6 +6,15 @@
   max-width: 800px;
   width: 100%;
 
+  textarea {
+    background: transparent;
+    border: none;
+    color: transparent;
+    height: 0;
+    position: relative;
+    width: 0;
+  }
+
   // Override the SimpleMDE styling
   .CodeMirror {
     background-color: transparent;

--- a/web/src/client/js/reducers/documentFields.js
+++ b/web/src/client/js/reducers/documentFields.js
@@ -30,7 +30,8 @@ export const documentFields = (state = initialState, action) => {
         return object
       }, {})
       const documentFieldsById = { ...state.documentFieldsById, [documentId]: documentFieldsObject }
-      return { ...state, documentFieldsById, loading: { ...state.loading, byDocument } }
+      const lastCreatedFieldId = initialState.lastCreatedFieldId
+      return { ...state, documentFieldsById, lastCreatedFieldId, loading: { ...state.loading, byDocument } }
     }
     case ActionTypes.RECEIVE_CREATED_FIELD: {
       const { id, documentId } = action.data
@@ -46,8 +47,10 @@ export const documentFields = (state = initialState, action) => {
       const { documentId, fieldId } = action
       const byId = { ...state.loading.byId, [fieldId]: true }
       const byDocument = { ...state.loading.byDocument, [documentId]: true }
+      const lastCreatedFieldId = initialState.lastCreatedFieldId
       return {
         ...state,
+        lastCreatedFieldId,
         loading: {
           ...state.loading,
           byDocument,
@@ -81,6 +84,7 @@ export const documentFields = (state = initialState, action) => {
       const documentFields = { ...state.documentFieldsById[documentId] }
       const { [fieldId]: fieldToUpdate, ...remainingFields } = documentFields
       const oldOrder = fieldToUpdate.order
+      const lastCreatedFieldId = initialState.lastCreatedFieldId
 
       // No change, early return
       if (oldOrder === newOrder) return { ...state }
@@ -113,6 +117,7 @@ export const documentFields = (state = initialState, action) => {
 
       return {
         ...state,
+        lastCreatedFieldId,
         documentFieldsById: {
           ...state.documentFieldsById,
           [documentId]: updatedFields
@@ -147,7 +152,8 @@ export const documentFields = (state = initialState, action) => {
       focused.id = fieldId
       focused.type = fieldType
       focused.data = fieldData
-      return { ...state, focused }
+      const lastCreatedFieldId = initialState.lastCreatedFieldId
+      return { ...state, lastCreatedFieldId, focused }
     }
     default:
       return state


### PR DESCRIPTION
* Added back the functionality to focus new body fields automatically
* Clears lastCreatedFieldId in more scenarios
* Hides textareas from flashing unstyled in Dirk's crazy Twitter documents (hopefully)