### PR TITLE
Fixing users list padding when in readOnly mode

### DIFF
--- a/web/src/client/js/components/Document/DocumentComponent.js
+++ b/web/src/client/js/components/Document/DocumentComponent.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link, useParams } from 'react-router-dom'
+import cx from 'classnames'
 
 import useDataService from 'Hooks/useDataService'
 import dataMapper from 'Libs/dataMapper'
@@ -66,6 +67,11 @@ const DocumentComponent = ({
     documentReadOnlyMode = projectAssignment == null || readOnlyRoleIds.includes(projectAssignment.roleId)
   }
 
+  const documentUsersClasses = cx({
+    'document__users-list': true,
+    'document__users-list--without-settings': documentReadOnlyMode
+  })
+
   const changeHandlerAction = debounce(500, (e) => {
     nameChangeHandler(e)
   })
@@ -121,7 +127,9 @@ const DocumentComponent = ({
             ref={titleRef} />
         </div>
         <OrgPlanPermission acceptedPlans={MULTI_USER_PLAN_TYPES}>
-          <DocumentUsersContainer />
+          <div className={documentUsersClasses}>
+            <DocumentUsersContainer />
+          </div>
         </OrgPlanPermission>
         <ProjectPermission acceptedRoleIds={[PROJECT_ROLE_IDS.ADMIN, PROJECT_ROLE_IDS.CONTRIBUTOR]}>
           <div className="document__toggle-container">

--- a/web/src/client/js/components/Document/_Document.scss
+++ b/web/src/client/js/components/Document/_Document.scss
@@ -128,6 +128,12 @@
 
   }
 
+  &__users-list {
+    &--without-settings {
+      padding: 0 1.8rem;
+    }
+  }
+
   &__fields {
     flex: 1;
     overflow-y: auto;


### PR DESCRIPTION
Fixes this spacing issue when in a readOnly doc and there are users in the doc

https://app.asana.com/0/1103604360526176/1165666014843865