### PR TITLE
fixing format menu with codemirror

### DIFF
--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -91,8 +91,11 @@ const DocumentFieldsContainer = ({
     }
   }
 
-  function fieldFocusHandler(fieldId, fieldType) {
+  function fieldFocusHandler(fieldId, fieldType, fieldData) {
+    // Unfortunately we're tracking focus state both in redux and within the sync
+    // context. We may want to look into hooking sync into redux? -Dirk 4/20
     if (!documentReadOnlyMode) {
+      focusField(fieldId, fieldType, fieldData)
       // send socket info
       socketDispatch(emitFieldFocus(socketDispatch, fieldId, documentId))
     }
@@ -100,6 +103,7 @@ const DocumentFieldsContainer = ({
 
   function fieldBlurHandler(fieldId, fieldType) {
     if (!documentReadOnlyMode) {
+      blurField(fieldId, fieldType)
       // send socket info
       socketDispatch(emitFieldBlur(socketDispatch, fieldId, documentId))
     }


### PR DESCRIPTION
I played around with this but couldn't figure out how we do this without a janky redux-esque connection between the format menu and codemirror instance(s). So it goes through redux. And sync also tracks focus in its context. I'm not sure how we could feed redux data to the sync context. I would like to keep them separate.