### PR TITLE
Fixes: Arrow key navigation of menus in production

### DIFF
--- a/web/run.sh
+++ b/web/run.sh
@@ -12,7 +12,7 @@ case $1 in
     npm run serve
     ;;
   local)
-    npm run build && API_PUBLIC_URL=http://localhost:3001 API_URL=http://localhost:3001 JWT_SECRET=jwtauthsecret NODE_ENV=production node dist/server/app.js
+    npm run build && API_PUBLIC_URL=http://localhost:3001 API_URL=http://localhost:3001 SYNC_URL=http://localhost:3004 JWT_SECRET=jwtauthsecret NODE_ENV=production node dist/server/app.js
     ;;
   install)
     npm install

--- a/web/src/client/js/components/Form/Form.js
+++ b/web/src/client/js/components/Form/Form.js
@@ -17,7 +17,7 @@ const Form = ({
   onSubmit,
   submitLabel,
   submitOnRight,
-  ...props,
+  ...props
 }) => {
   const formRef = useRef()
   const [formChanged, setFormChanged] = useState(false)

--- a/web/src/client/js/components/Menu/Menu.js
+++ b/web/src/client/js/components/Menu/Menu.js
@@ -48,7 +48,7 @@ const Menu = ({ anchorRef, className, children, isActive, ...props }) => {
         activeFirstTime.current = false
       }
       const menuItemComponents = React.Children.toArray(children).filter((child) => {
-        return child.type.name === 'MenuItem'
+        return child.type.displayName === 'MenuItem'
       })
       const menuItemChildren = menuItemComponents.map((child) => {
         return child.props.children

--- a/web/src/client/js/components/Menu/MenuItem.js
+++ b/web/src/client/js/components/Menu/MenuItem.js
@@ -15,6 +15,8 @@ const MenuItem = ({ className, children, padded, ...props }) => {
   )
 }
 
+MenuItem.displayName = 'MenuItem'
+
 MenuItem.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,


### PR DESCRIPTION
MenuItem's displayName was getting mangled in production. Setting an explicit displayName on the component fixed an issue where you couldn't arrow nav menus in prod.

Also fixes running prod locally