### PR TITLE
Updates: scroll position when splitting a text field

### DIFF
--- a/web/src/client/js/actions/field.js
+++ b/web/src/client/js/actions/field.js
@@ -208,8 +208,16 @@ export const createNewFieldWithTheSplitOfThePreviousFieldAndReOrderThemAppropria
     // removed this and am manually calling the field update API so we don't get an onChange
     // editor.replaceRange('', startRange, endRange)
 
+    // Save the current window position so nothing moves
+    const df = document.querySelector('.document__fields')
+    const oldHeight = df.offsetHeight
+    const oldScrollTop = df.scrollTop
+
     // Fetch the document for a total re-render now that we have everything set up
-    dispatch(fetchDocument(documentId))
+    dispatch(fetchDocument(documentId)).then(() => {
+      // When the document re-renders, set its scroll manually to where it was before
+      df.scrollTop = oldScrollTop + (df.offsetHeight - oldHeight)
+    })
     dispatch(Fields.setLastCreatedFieldId(newField.id))
 
     if (socketDispatch) {

--- a/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
@@ -86,15 +86,6 @@ const DocumentFieldComponent = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [field.id, field.value])
 
-  useEffect(() => {
-    if (isNewField) {
-      // Scroll to the center of the new field
-      window.requestAnimationFrame(() => {
-        fieldRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      })
-    }
-  }, [isNewField])
-
   function handleFieldBodyUpdate(fieldId, body) {
     // Note it is a very bad, no good idea to do anything in this callback beyond pass the change
     // up the chain of callbacks. Any actions performed here that invokes DocumentFieldsContainer


### PR DESCRIPTION
No longer jumps things around. We save the scroll position of document__fields before re-render, and set it back to that. 

Adding a new field shouldn't move the document at all now, feels much nicer.