### PR TITLE
Fixes: File field's name widths were off when adding a new file

### DIFF
--- a/web/src/client/js/components/DocumentFields/_DocumentField.scss
+++ b/web/src/client/js/components/DocumentFields/_DocumentField.scss
@@ -72,10 +72,10 @@
     align-items: flex-start;
     border-right: thin solid var(--theme-border);
     display: flex;
-    flex: 0 0 var(--field-name-width);
     flex-direction: column;
     justify-content: center;
     padding: .7rem 1.2rem;
+    width: var(--field-name-width);
   }
 
   &-label {


### PR DESCRIPTION
Try creating a file with the name `Screen Shot 2020-04-16 at 11.19.50 AM.png` on release and you'll see:

![image](https://user-images.githubusercontent.com/2809/79607016-658f3800-80a7-11ea-9288-eb7916d7e342.png)

Now you should see the normal field name width like everything else