### PR TITLE
New: Notify users when there's a new version of the web app

### DIFF
--- a/web/src/client/js/components/Notifications/NotificationComponent.js
+++ b/web/src/client/js/components/Notifications/NotificationComponent.js
@@ -46,7 +46,10 @@ NotificationComponent.propTypes = {
   notification: PropTypes.shape({
     code: PropTypes.number,
     resource: PropTypes.string,
-    message: PropTypes.string.isRequired,
+    message: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node,
+    ]).isRequired,
     type: PropTypes.string.isRequired
   })
 }

--- a/web/src/client/js/utilities/registerServiceWorker.js
+++ b/web/src/client/js/utilities/registerServiceWorker.js
@@ -1,3 +1,10 @@
+import React from 'react'
+
+import { createNotification } from 'Actions/notifications'
+import { NOTIFICATION_TYPES } from 'Shared/constants'
+
+import Store from '../reducers'
+
 export default function register() {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
@@ -10,7 +17,12 @@ export default function register() {
             installingWorker.onstatechange = () => {
               if (installingWorker.state === 'installed') {
                 if (navigator.serviceWorker.controller) {
-                  console.info('New content is available; please refresh.')
+                  const message = (
+                    <>
+                      🎁 An update to Portway is available. <a href={location.href}>Refresh for the latest updates!</a>
+                    </>
+                  )
+                  Store.dispatch(createNotification(message, NOTIFICATION_TYPES.SUCCESS))
                 } else {
                   console.info('Content is cached for offline use.')
                 }

--- a/web/src/client/js/utilities/registerServiceWorker.js
+++ b/web/src/client/js/utilities/registerServiceWorker.js
@@ -20,7 +20,7 @@ export default function register() {
                   console.info('An update to Portway is available. Refresh for the latest updates!')
                   const message = (
                     <>
-                      🎁 An update to Portway is available. <a href={location.href}>Refresh for the latest updates!</a>
+                      🚚 An update to Portway has been delivered. <a href={location.href}>Refresh for the latest updates!</a>
                     </>
                   )
                   Store.dispatch(createNotification(message, NOTIFICATION_TYPES.SUCCESS))

--- a/web/src/client/js/utilities/registerServiceWorker.js
+++ b/web/src/client/js/utilities/registerServiceWorker.js
@@ -20,7 +20,7 @@ export default function register() {
                   console.info('An update to Portway is available. Refresh for the latest updates!')
                   const message = (
                     <>
-                      🚚 An update to Portway has been delivered. <a href={location.href}>Refresh for the latest updates!</a>
+                      🚚 An update to Portway has been delivered. <a href={location.href}>Refresh for the latest changes!</a>
                     </>
                   )
                   Store.dispatch(createNotification(message, NOTIFICATION_TYPES.SUCCESS))

--- a/web/src/client/js/utilities/registerServiceWorker.js
+++ b/web/src/client/js/utilities/registerServiceWorker.js
@@ -17,6 +17,7 @@ export default function register() {
             installingWorker.onstatechange = () => {
               if (installingWorker.state === 'installed') {
                 if (navigator.serviceWorker.controller) {
+                  console.info('An update to Portway is available. Refresh for the latest updates!')
                   const message = (
                     <>
                       🎁 An update to Portway is available. <a href={location.href}>Refresh for the latest updates!</a>


### PR DESCRIPTION
Prompts user to refresh when app bundle is different.
You can only test this in prod, when the app bundle has changed from the cached one. 

Looks like this:

<img width="357" alt="Screen Shot 2020-04-17 at 1 05 36 PM" src="https://user-images.githubusercontent.com/2809/79610056-ab023400-80ac-11ea-9e3b-115acc45db38.png">
