### PR TITLE
Fixes: doc toolbar from appearing when it shouldn't

### DIFF
--- a/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
+++ b/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
@@ -29,7 +29,7 @@ const DocumentToolbarContainer = ({
     location.pathname
   ])
 
-  if (!document) return null
+  if (!documentId || !document) return null
 
   if (isCreating && documentId === PATH_DOCUMENT_NEW_PARAM) {
     return null


### PR DESCRIPTION
This fixes the bug, but I'm not sure why `currentResource` still returns a document when `matchResults` is null. 