### PR TITLE
fix field name flash

### DIFF
--- a/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 
 import { FIELD_TYPES, SYNC_SINGLE_USER_EDIT_FIELDS } from 'Shared/constants'
 import { currentUserId } from 'Libs/currentIds'
+import usePrevious from 'Hooks/usePrevious'
 
 import DocumentUsersComponent from 'Components/DocumentUsers/DocumentUsersComponent'
 import { Popper } from 'Components/Popper/Popper'
@@ -41,6 +42,7 @@ const DocumentFieldComponent = ({
 }) => {
   const remoteChangesRef = useRef([])
   const nameRef = useRef()
+  const previousFieldName = usePrevious(field.name)
   const toolsRef = useRef()
   const fieldRef = useRef()
 
@@ -156,10 +158,10 @@ const DocumentFieldComponent = ({
 
   // field name has been updated, set the uncontrolled value
   useEffect(() => {
-    if (!isCurrentlyFocusedField && nameRef.current && field.name !== nameRef.current.value) {
+    if (!isCurrentlyFocusedField && nameRef.current && field.name !== nameRef.current.value && field.name !== previousFieldName) {
       nameRef.current.value = field.name
     }
-  }, [field.name, isCurrentlyFocusedField])
+  }, [field.name, isCurrentlyFocusedField, previousFieldName])
 
   const dataField = DATA_FIELD_TYPES.includes(field.type)
 

--- a/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
@@ -42,7 +42,7 @@ const DocumentFieldComponent = ({
 }) => {
   const remoteChangesRef = useRef([])
   const nameRef = useRef()
-  const previousFieldName = usePrevious(field.name)
+  const previousField = usePrevious(field)
   const toolsRef = useRef()
   const fieldRef = useRef()
 
@@ -85,12 +85,12 @@ const DocumentFieldComponent = ({
   }, [remoteChangesRef.current.length, singleUserEditField])
 
   useEffect(() => {
-    // Accept remote changes to field if it's not focused and the conflict popper isn't open
-    if (!isCurrentlyFocusedField && !showConflictPopper) {
+    // Accept remote changes to field if it's not focused, the conflict popper isn't open, and the field value has changed
+    if (!isCurrentlyFocusedField && !showConflictPopper && previousField !== field && !isUpdating) {
       setCurrentValue(field.value)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [field.id, field.value])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [field, isUpdating])
 
   function handleFieldBodyUpdate(fieldId, body) {
     // Note it is a very bad, no good idea to do anything in this callback beyond pass the change
@@ -158,10 +158,10 @@ const DocumentFieldComponent = ({
 
   // field name has been updated, set the uncontrolled value
   useEffect(() => {
-    if (!isCurrentlyFocusedField && nameRef.current && field.name !== nameRef.current.value && field.name !== previousFieldName) {
+    if (!isCurrentlyFocusedField && nameRef.current && field.name !== nameRef.current.value && !isUpdating && previousField !== field) {
       nameRef.current.value = field.name
     }
-  }, [field.name, isCurrentlyFocusedField, previousFieldName])
+  }, [field, isCurrentlyFocusedField, previousField, isUpdating])
 
   const dataField = DATA_FIELD_TYPES.includes(field.type)
 

--- a/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
@@ -90,7 +90,7 @@ const DocumentFieldComponent = ({
       setCurrentValue(field.value)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [field, isUpdating])
+  }, [field, isUpdating, previousField])
 
   function handleFieldBodyUpdate(fieldId, body) {
     // Note it is a very bad, no good idea to do anything in this callback beyond pass the change

--- a/web/src/client/js/components/FieldImage/FieldImageComponent.js
+++ b/web/src/client/js/components/FieldImage/FieldImageComponent.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 import useIsMounted from 'Hooks/useIsMounted'
+import usePrevious from 'Hooks/usePrevious'
 
 import { MAX_FILE_SIZE } from 'Shared/constants'
 import { RemoveIcon, EditIcon } from 'Components/Icons'
@@ -52,10 +53,11 @@ const FieldImageComponent = ({
   const [imageDetails, setImageDetails] = useState({}) // image metadata
   const isUpdatingTheActualImage = settingsMode && updating && previewRef.current
   const nameRef = useRef()
+  const previousFieldName = usePrevious(field.name)
 
   // Name
   // There was a field name change and we're not currently focused, update the uncontrolled value
-  if (nameRef.current && field.name !== nameRef.current && !isCurrentlyFocusedField) {
+  if (nameRef.current && field.name !== nameRef.current && !isCurrentlyFocusedField && field.name !== previousFieldName) {
     nameRef.current.value = field.name
   }
 

--- a/web/src/client/js/components/FieldImage/FieldImageComponent.js
+++ b/web/src/client/js/components/FieldImage/FieldImageComponent.js
@@ -53,11 +53,11 @@ const FieldImageComponent = ({
   const [imageDetails, setImageDetails] = useState({}) // image metadata
   const isUpdatingTheActualImage = settingsMode && updating && previewRef.current
   const nameRef = useRef()
-  const previousFieldName = usePrevious(field.name)
+  const previousField = usePrevious(field)
 
   // Name
   // There was a field name change and we're not currently focused, update the uncontrolled value
-  if (nameRef.current && field.name !== nameRef.current && !isCurrentlyFocusedField && field.name !== previousFieldName) {
+  if (nameRef.current && field.name !== nameRef.current && !isCurrentlyFocusedField && field !== previousField) {
     nameRef.current.value = field.name
   }
 

--- a/web/src/client/js/hooks/usePrevious.js
+++ b/web/src/client/js/hooks/usePrevious.js
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react'
+
+export default function usePrevious(value) {
+  const ref = useRef()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}


### PR DESCRIPTION
- adds a nifty usePrevious hook that will return the previous value on each re-render
- adds a check for generic name changes and image name changes, if the incoming field.name is the same as the previous one, we know not to update the current.value