### PR TITLE
Updating CodeMirror and removing dividers

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -53,7 +53,7 @@
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.4",
     "classnames": "^2.2.6",
-    "codemirror": "^5.52.2",
+    "codemirror": "^5.53.2",
     "compression-webpack-plugin": "^3.1.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^1.0.0",

--- a/web/src/client/js/components/ContentMenu/ContentMenuComponent.js
+++ b/web/src/client/js/components/ContentMenu/ContentMenuComponent.js
@@ -57,11 +57,10 @@ const ContentMenuComponent = ({ createFieldHandler }) => {
         placement="bottom"
         width="130"
       >
-        <MenuHeader><h2>Content</h2></MenuHeader>
         <Menu anchorRef={anchorRef} isActive={expanded}>
           <MenuItem>
             <button className="btn btn--blank btn--with-icon" onClick={() => { createFieldHandler(FIELD_TYPES.TEXT) }} ref={React.createRef()}>
-              <TextIcon width="26" height="26" /> <span className="label">Body</span>
+              <TextIcon width="26" height="26" /> <span className="label">Text</span>
             </button>
           </MenuItem>
           <MenuItem>
@@ -69,7 +68,6 @@ const ContentMenuComponent = ({ createFieldHandler }) => {
               <ImageIcon width="26" height="26" /> <span className="label">Image</span>
             </button>
           </MenuItem>
-          <MenuDivider><h2>Data</h2></MenuDivider>
           <MenuItem>
             <button className="btn btn--blank btn--with-icon" onClick={() => { createFieldHandler(FIELD_TYPES.STRING) }} ref={React.createRef()}>
               <StringIcon width="26" height="26" /> <span className="label">String</span>


### PR DESCRIPTION
* Updates to 5.53.2 for a CodeMirror.refresh() bug with wrapping text
* Removes "Content" and "Data" from content menu