### PR TITLE
fix empty payload validation

### DIFF
--- a/api/src/controllers/organizations.js
+++ b/api/src/controllers/organizations.js
@@ -10,6 +10,7 @@ import RESOURCE_TYPES from '../constants/resourceTypes'
 import ACTIONS from '../constants/actions'
 import { requiredFields } from './payloadSchemas/helpers'
 import orgSchema from './payloadSchemas/organization'
+import emptySchema from './payloadSchemas/empty'
 import avatarCoordinator from '../coordinators/avatar'
 import organizationCoordinator from '../coordinators/organization'
 
@@ -69,7 +70,7 @@ const organizationsController = function(router) {
         fileSize: MAX_AVATAR_FILE_SIZE
       }
     }).single('file'),
-    validateBody(Joi.compile({})),
+    validateBody(emptySchema),
     conditionalUpdatePerm,
     updateOrganizationAvatar
   )

--- a/api/src/controllers/organizations.js
+++ b/api/src/controllers/organizations.js
@@ -69,7 +69,7 @@ const organizationsController = function(router) {
         fileSize: MAX_AVATAR_FILE_SIZE
       }
     }).single('file'),
-    validateBody({}),
+    validateBody(Joi.compile({})),
     conditionalUpdatePerm,
     updateOrganizationAvatar
   )

--- a/api/src/controllers/payloadSchemas/empty.js
+++ b/api/src/controllers/payloadSchemas/empty.js
@@ -1,0 +1,2 @@
+import Joi from '@hapi/joi'
+export default Joi.compile({})

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -12,6 +12,7 @@ import perms from '../libs/middleware/reqPermissionsMiddleware'
 import ACTIONS from '../constants/actions'
 import { requiredFields } from './payloadSchemas/helpers'
 import userSchema from './payloadSchemas/user'
+import emptySchema from './payloadSchemas/empty'
 import { SORT_METHODS } from '../constants/queryOptions'
 import avatarCoordinator from '../coordinators/avatar'
 
@@ -108,7 +109,7 @@ const usersController = function(router) {
         fileSize: MAX_AVATAR_FILE_SIZE
       }
     }).single('file'),
-    validateBody(Joi.compile({})),
+    validateBody(emptySchema),
     conditionalUpdatePerm,
     updateUserAvatar
   )

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -108,7 +108,7 @@ const usersController = function(router) {
         fileSize: MAX_AVATAR_FILE_SIZE
       }
     }).single('file'),
-    validateBody({}),
+    validateBody(Joi.compile({})),
     conditionalUpdatePerm,
     updateUserAvatar
   )

--- a/api/src/libs/middleware/payloadValidation.js
+++ b/api/src/libs/middleware/payloadValidation.js
@@ -1,6 +1,4 @@
 import ono from 'ono'
-import Joi from '@hapi/joi'
-
 import apiErrorTypes from '../../constants/apiErrorTypes'
 import PUBLIC_MESSAGES from '../../constants/publicMessages'
 


### PR DESCRIPTION
I only saw this on multer-backed endpoints for avatars, not really sure how this ever worked, but maybe broke with the joi upgrade?