### PR TITLE
Fixes: focusing of new fields

### DIFF
--- a/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldComponent.js
@@ -91,6 +91,12 @@ const DocumentFieldComponent = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [field, isUpdating, previousField])
 
+  useEffect(() => {
+    if (isNewField && fieldRef.current) {
+      fieldRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [isNewField])
+
   function handleFieldBodyUpdate(fieldId, body) {
     // Note it is a very bad, no good idea to do anything in this callback beyond pass the change
     // up the chain of callbacks. Any actions performed here that invokes DocumentFieldsContainer

--- a/web/src/client/js/components/FieldNumber/FieldNumberComponent.js
+++ b/web/src/client/js/components/FieldNumber/FieldNumberComponent.js
@@ -1,8 +1,25 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { FIELD_TYPES } from 'Shared/constants'
 
-const FieldNumberComponent = ({ autoFocusElement, id, type, value, onBlur, onChange, onFocus, readOnly, documentId }) => {
+const FieldNumberComponent = ({
+  autoFocusElement,
+  id,
+  type,
+  value,
+  onBlur,
+  onChange,
+  onFocus,
+  readOnly,
+  documentId
+}) => {
+  const focusRef = useRef()
+  useEffect(() => {
+    if (autoFocusElement && focusRef.current) {
+      focusRef.current.focus()
+    }
+  }, [autoFocusElement])
+
   const handleChange = (e) => {
     // API will only handle 15 significant digits for number fields
     if (e.target.value.length > 15) return
@@ -33,6 +50,7 @@ const FieldNumberComponent = ({ autoFocusElement, id, type, value, onBlur, onCha
       }}
       placeholder="A number value..."
       readOnly={readOnly}
+      ref={focusRef}
       type="number" />
   )
 }

--- a/web/src/client/js/components/FieldString/FieldStringComponent.js
+++ b/web/src/client/js/components/FieldString/FieldStringComponent.js
@@ -1,8 +1,24 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { FIELD_TYPES } from 'Shared/constants'
 
-const FieldStringComponent = ({ autoFocusElement, id, type, value, documentId, onBlur, onChange, onFocus, readOnly }) => {
+const FieldStringComponent = ({
+  autoFocusElement,
+  id,
+  type,
+  value,
+  documentId,
+  onBlur,
+  onChange,
+  onFocus,
+  readOnly
+}) => {
+  const focusRef = useRef()
+  useEffect(() => {
+    if (autoFocusElement && focusRef.current) {
+      focusRef.current.focus()
+    }
+  }, [autoFocusElement])
   return (
     <input
       // eslint-disable-next-line jsx-a11y/no-autofocus
@@ -21,6 +37,7 @@ const FieldStringComponent = ({ autoFocusElement, id, type, value, documentId, o
       }}
       placeholder="A string value..."
       readOnly={readOnly}
+      ref={focusRef}
       type="text" />
   )
 }


### PR DESCRIPTION
* Should scroll new fields into view, no matter the field type
* Should focus the string, number, or text field
* Should work on both split fields and not split fields