### PR TITLE
bump org rate limit

### DIFF
--- a/api/src/libs/rateLimiter.js
+++ b/api/src/libs/rateLimiter.js
@@ -12,7 +12,7 @@ const result = await limiter.reserve(key, limit)
 const {token, usage, reset} = result
 */
 
-export const REQ_LIMIT = 200
+export const REQ_LIMIT = 1000 // 200 req/min per 5 user org
 const TIME_INTERVAL_MS = 60000 // 1 min
 
 const options = {


### PR DESCRIPTION
Puts it at 1000 per org, so for a 5 user org each user gets 200 req/min which is hard to hit, I have to refresh the app ~18 times in a row to hit 200 req/min. Each refresh is 11 requests