### PR TITLE
cast to string for documentId in sync focusField event

### DIFF
--- a/sync/src/socketControllers/documents.js
+++ b/sync/src/socketControllers/documents.js
@@ -1,5 +1,7 @@
 import redis from '../libs/redis'
 import { extractJwtPayloadWithoutVerification } from '../libs/ioAuth'
+import logger from '../libs/logger'
+import { LOG_LEVELS } from '../constants'
 
 const USER_SOCKET_ROOM_CACHE_EXPIRATION = 60 * 60// 1 hour
 const USER_SOCKET_FOCUSED_FIELD_EXPIRATION = 60 * 5// 5 minutes
@@ -46,7 +48,10 @@ export default (io) => {
     }
 
     const joinRoom = async (documentId) => {
-      if (typeof documentId !== 'string') return
+      if (typeof documentId !== 'string') {
+        logger(LOG_LEVELS.WARNING, `joinRoom for document id ${documentId} expects a string, received ${typeof documentId}`)
+        return
+      }
 
       const currentDocumentRoomId = await redis.get(userSocketRoomNs)
       if (currentDocumentRoomId === documentId) return

--- a/web/src/client/js/actions/userSync.js
+++ b/web/src/client/js/actions/userSync.js
@@ -29,7 +29,7 @@ export const emitFieldFocus = (fieldId, documentId) => {
       return dispatch(UserSync.socketError())
     }
     dispatch(UserSync.emitFieldFocus(fieldId))
-    documentSocket.emit('fieldFocus', fieldId, documentId)
+    documentSocket.emit('fieldFocus', fieldId, String(documentId))
     dispatch(UserSync.fieldFocusEmitted(fieldId))
   }
 }


### PR DESCRIPTION
- Fixes bug where focusField wasn't forcing user to join room if user was not in room (in this case caused by redis expiring the user in the room)
- Adds logging to help identify this issue going forward

I had many theories about what was happening, and most of them were wrong. At least I validated a lot of the sync functionality though?