### PR TITLE
new admin route for updating org billing status and fetching orgs

### DIFF
--- a/api/src/businesstime/organization.js
+++ b/api/src/businesstime/organization.js
@@ -19,6 +19,12 @@ async function create(body) {
   return publicFields(createdOrg)
 }
 
+
+async function findAll() {
+  const db = getDb()
+  return await db.model(MODEL_NAME).findAll({ attributes: PUBLIC_FIELDS, raw: true })
+}
+
 async function findSanitizedById(id) {
   const db = getDb()
 
@@ -85,6 +91,7 @@ export default {
   create,
   findSanitizedById,
   updateById,
+  findAll,
   findById,
   findByStripeId,
   deleteById,

--- a/api/src/controllers/admin.js
+++ b/api/src/controllers/admin.js
@@ -7,29 +7,33 @@ import adminAuth from '../libs/auth/adminAuth'
 import demoSignupCoordinator from '../coordinators/demoSignup'
 import BusinessOrganization from '../businesstime/organization'
 import organizationCoordinator from '../coordinators/organization'
-
-/**
- * Sample Payload
- *
-{
-  "adminKey": "****",
-  "name": "Org Name",
-  "users": [
-    {
-      "name": "BobbyBong 1",
-      "email": "example1@bonkeybong.com",
-      "role": 1
-    }
-  ]
-}
-*/
+import billingCoordinator from '../coordinators/billing'
 
 const adminController = function(router) {
+  /**
+   * Sample Payload
+   *
+  {
+    "adminKey": "****",
+    "name": "Org Name",
+    "users": [
+      {
+        "name": "BobbyBong 1",
+        "email": "example1@bonkeybong.com",
+        "role": 1
+      }
+    ]
+  }
+  */
   router.post('/demoAccount',
     bodyParser.json(),
     adminAuth,
     createAccount
   )
+
+  router.get('/organizations', adminAuth, getOrganizations)
+
+  router.post('/organizations/:id/updateBillingStatus', adminAuth, updateOrgBillingStatus)
 
   router.delete('/organizations/:id',
     adminAuth,
@@ -49,6 +53,25 @@ const createAccount = async function(req, res, next) {
     await demoSignupCoordinator.createUsersAndOrganization(name, users)
     res.json({ success: true })
   } catch (e) {
+    next(e)
+  }
+}
+
+const getOrganizations = async function(req, res, next) {
+  try {
+    // TODO: switch back to findAll() after testing
+    const orgs = await BusinessOrganization.findAll()
+    res.json({data: orgs})
+  } catch (e) {
+    next(e)
+  }
+}
+
+const updateOrgBillingStatus = async function(req, res, next) {
+  try {
+    await billingCoordinator.fetchCustomerAndSetSubscriptionDataOnOrg(req.params.id)
+    res.status(200).send()
+  } catch(e) {
     next(e)
   }
 }

--- a/api/src/controllers/admin.js
+++ b/api/src/controllers/admin.js
@@ -59,7 +59,6 @@ const createAccount = async function(req, res, next) {
 
 const getOrganizations = async function(req, res, next) {
   try {
-    // TODO: switch back to findAll() after testing
     const orgs = await BusinessOrganization.findAll()
     res.json({data: orgs})
   } catch (e) {


### PR DESCRIPTION
Required by https://github.com/BonkeyBong/portway-ops/pull/3

The fetchAll on BusinessOrgs should be paginated at some point, but running the job locally with 70 orgs is fine. When we get more orgs we'll probably need a different runner structure to handle these updates