### PR TITLE
Fixes: Removes color from project team if avatar present

### DIFF
--- a/web/src/client/js/components/ProjectUsers/ProjectUsersCollapsedItem.js
+++ b/web/src/client/js/components/ProjectUsers/ProjectUsersCollapsedItem.js
@@ -5,7 +5,7 @@ const ProjectUsersCollapsedItem = ({ color, user }) => {
   const firstInitial = user.name.charAt(0).toUpperCase()
   const itemStyle = {
     backgroundImage: user.avatar ? `url('${user.avatar}')` : 'none',
-    backgroundColor: color
+    backgroundColor: user.avatar ? 'transparent' : color
   }
   return (
     <li className="project-users__collapsed-item" style={itemStyle} title={user.name}>


### PR DESCRIPTION
Prevents random colors from appearing for transparent pngs/svgs. If the color was specific per user I wouldn't mind, but it looks like a bug with a bunch of different colors on the same user