### PR TITLE
Fixes: Image fields with tiny images displayed funky

### DIFF
--- a/web/src/client/js/components/FieldImage/FieldImage.scss
+++ b/web/src/client/js/components/FieldImage/FieldImage.scss
@@ -66,7 +66,9 @@
 .document-field__image-container {
   align-items: center;
   display: flex;
+  justify-content: center;
   min-height: 135px;
+  min-width: 200px;
   position: relative;
 }
 


### PR DESCRIPTION
Try an image that's like 24x24 and you'll see that it no longer looks terrible