### PR TITLE
Fix tests with new docker images

### DIFF
--- a/api/run.sh
+++ b/api/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # pipefail only seems to work with alpine's sh
-# set -e pipefail
+set -e
 
 echo "run.sh"
 

--- a/api/run.sh
+++ b/api/run.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# pipefail only seems to work with alpine's sh
 set -e
 
 echo "run.sh"

--- a/api/wait-for.sh
+++ b/api/wait-for.sh
@@ -31,6 +31,7 @@ wait_for() {
     if [ $result -eq 0 ] ; then
       if [ $# -gt 0 ] ; then
         echo "wait-for.sh: successfully connected"
+        sleep 2
         exec "$@"
       fi
       exit 0

--- a/sync/run.sh
+++ b/sync/run.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-# alpine only pipefail
-# set -eo pipefail
+set -e
 
 case $1 in
   start)

--- a/web/run.sh
+++ b/web/run.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-# alpine-only option
-# set -eo pipefail
+set -e
 
 case $1 in
   start)


### PR DESCRIPTION
For whatever reason, the database needed a few more seconds to startup. The migrate command was running before the db was ready for commands, even though it was responding on the host and port.

At least, that seems to be the case.