### PR TITLE
Fixes: new document item was hidden on scrolled lists

### DIFF
--- a/web/src/client/js/components/DocumentsList/DocumentsListCreateItem.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListCreateItem.js
@@ -15,6 +15,7 @@ const DocumentsListCreateItem = ({ active, createDocumentHandler, isCreating, to
   // Select the contents of the contentEditable div (new document name)
   useEffect(() => {
     if (active && nameRef.current && !isCreating) {
+      listItemRef.current.scrollIntoView({ block: 'end' })
       nameRef.current.select()
     }
   })


### PR DESCRIPTION
If you had a long document list, clicking "New document" or Ctrl-N wouldn't scroll the list up to the top