### PR TITLE
emit blur event with doc id as string

### DIFF
--- a/web/src/client/js/actions/userSync.js
+++ b/web/src/client/js/actions/userSync.js
@@ -7,6 +7,8 @@ export const emitJoinDocumentRoom = (documentId) => {
       return UserSync.socketError()
     }
     dispatch(UserSync.emitJoinDocumentRoom(documentId))
+    console.log('emitting joinRoom for ' + documentId)
+    console.log(typeof documentId)
     documentSocket.emit('joinRoom', documentId)
     dispatch(UserSync.documentRoomJoined(documentId))
   }
@@ -40,7 +42,7 @@ export const emitFieldBlur = (fieldId, documentId) => {
       return dispatch(UserSync.socketError())
     }
     dispatch(UserSync.emitFieldBlur(fieldId))
-    documentSocket.emit('fieldFocus', null, documentId)
+    documentSocket.emit('fieldFocus', null, String(documentId))
     dispatch(UserSync.fieldBlurEmitted(fieldId))
   }
 }

--- a/web/src/client/js/actions/userSync.js
+++ b/web/src/client/js/actions/userSync.js
@@ -7,8 +7,6 @@ export const emitJoinDocumentRoom = (documentId) => {
       return UserSync.socketError()
     }
     dispatch(UserSync.emitJoinDocumentRoom(documentId))
-    console.log('emitting joinRoom for ' + documentId)
-    console.log(typeof documentId)
     documentSocket.emit('joinRoom', documentId)
     dispatch(UserSync.documentRoomJoined(documentId))
   }


### PR DESCRIPTION
This was causing an error on document join room, since it wants a string, not a number. Also makes it consistent with the other events, which all seem to be passing strings