### PR TITLE
Adds .well-known to server public dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ yarn-error.log*
 
 # Build data
 .vscode
+.nova
 stats.json
 
 # Runtime data

--- a/web/config/webpack.shared.js
+++ b/web/config/webpack.shared.js
@@ -26,7 +26,11 @@ const SharedConfig = {
       {
         from: path.resolve(__dirname, '../src/client/manifest.json'),
         to: 'manifest.json'
-      }
+      },
+      {
+        from: path.resolve(__dirname, '../src/server/.well-known'),
+        to: '.well-known'
+      },
     ]),
     new SWPrecacheWebpackPlugin({
       cacheId: Constants.PRODUCT_ID,

--- a/web/src/server/.well-known/apple-app-site-association
+++ b/web/src/server/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+	  "applinks": {
+		  "details": [
+			   {
+				 "appIDs": ["Y254DPS4AY.com.bonkeybong.portway"],
+				 "components": [
+				   {
+					  "/": "/d/*",
+					  "comment": "Matches any URL whose path starts with /d/"
+				   }
+				 ]
+			   }
+		   ]
+	   }
+	}


### PR DESCRIPTION
Adds a /.well-known/apple-app-site-association file to the web server for iOS/macOS associated domains. Apparently this can be used for[ other services](https://en.wikipedia.org/wiki/List_of_%2F.well-known%2F_services_offered_by_webservers) too.

I tested by running Portway production locally, and hitting that URL to download the file. It shouldn't have a file extension, but it's JSON

