### PR TITLE
Fixes payment expiration date display

### DIFF
--- a/web/src/client/js/components/Admin/AdminPayment/AdminPaymentComponent.js
+++ b/web/src/client/js/components/Admin/AdminPayment/AdminPaymentComponent.js
@@ -73,6 +73,8 @@ const AdminPaymentComponent = ({
 
   if (orgBilling && orgBilling.source) {
     const cost = orgBilling.subscription && toCurrencyString(getTotalCost(orgBilling.subscription))
+    // Using the YYYY-M-D format because expYear and expMonth may be single or double digit from the API
+    // and Moment needs to have a valid format for display
     const expDateCalc = moment(`${orgBilling.source.expYear}-${orgBilling.source.expMonth}-01`, 'YYYY-M-D')
     const expDate = moment(`${orgBilling.source.expYear}-${orgBilling.source.expMonth}-01`, 'YYYY-M-D')
     const expiringSoon = moment() > expDateCalc.add(1, 'months')

--- a/web/src/client/js/components/Admin/AdminPayment/AdminPaymentComponent.js
+++ b/web/src/client/js/components/Admin/AdminPayment/AdminPaymentComponent.js
@@ -73,8 +73,8 @@ const AdminPaymentComponent = ({
 
   if (orgBilling && orgBilling.source) {
     const cost = orgBilling.subscription && toCurrencyString(getTotalCost(orgBilling.subscription))
-    const expDateCalc = moment(`${orgBilling.source.expYear}-${orgBilling.source.expMonth}-01`)
-    const expDate = moment(`${orgBilling.source.expYear}-${orgBilling.source.expMonth}-01`)
+    const expDateCalc = moment(`${orgBilling.source.expYear}-${orgBilling.source.expMonth}-01`, 'YYYY-M-D')
+    const expDate = moment(`${orgBilling.source.expYear}-${orgBilling.source.expMonth}-01`, 'YYYY-M-D')
     const expiringSoon = moment() > expDateCalc.add(1, 'months')
     const nextBillingDate = moment.unix(orgBilling.subscription.currentPeriodEnd)
 


### PR DESCRIPTION
If a users card expired on a month <= 9, moment would have an invalid date due to the string we were making. https://github.com/moment/moment/issues/2554