### PR TITLE
Fixes rendering bug in plan selector on Safari 14

### DIFF
--- a/web/src/client/js/components/Admin/AdminPlanSelector/AdminPlanSelectorComponent.js
+++ b/web/src/client/js/components/Admin/AdminPlanSelector/AdminPlanSelectorComponent.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
+import { getBrowser } from 'Utilities/browserUtils'
+
 import {
   FREE_PLAN_TYPES,
   LOCKED_ACCOUNT_STATUSES,
@@ -49,6 +51,12 @@ const AdminPlanSelectorComponent = ({
   const adminPlanClasses = cx({
     'admin-plans-selector': true,
     'admin-plans-selector--disabled': lockedSubscription
+  })
+
+  const isSafari13 = getBrowser().name === 'Safari' && Number(getBrowser().version) < 14
+  const adminPriceClasses = cx({
+    'admin-plans-selector__price': true,
+    'admin-plans-selector__price--safari-fix': isSafari13
   })
 
   return (
@@ -149,7 +157,7 @@ const AdminPlanSelectorComponent = ({
                     </ul>
                   </div>
                 </div>
-                <span className="admin-plans-selector__price">
+                <span className={adminPriceClasses}>
                 $50/mo {organizationPlan === PLAN_TYPES.MULTI_USER && <>(Your plan)</>}
                 </span>
               </button>

--- a/web/src/client/js/components/Admin/AdminPlanSelector/_AdminPlanSelector.scss
+++ b/web/src/client/js/components/Admin/AdminPlanSelector/_AdminPlanSelector.scss
@@ -134,7 +134,7 @@
     font-weight: 700;
     margin: 2rem 0 0 0;
     padding: 1rem 2rem;
-    width: 400%; // Safari bug
+    width: 100%;
 
     [aria-checked="true"] & {
       background-color: var(--color-green);

--- a/web/src/client/js/components/Admin/AdminPlanSelector/_AdminPlanSelector.scss
+++ b/web/src/client/js/components/Admin/AdminPlanSelector/_AdminPlanSelector.scss
@@ -136,6 +136,10 @@
     padding: 1rem 2rem;
     width: 100%;
 
+    &--safari-fix {
+      width: 400%;
+    }
+
     [aria-checked="true"] & {
       background-color: var(--color-green);
     }

--- a/web/src/client/js/utilities/browserUtils.js
+++ b/web/src/client/js/utilities/browserUtils.js
@@ -1,0 +1,17 @@
+export function getBrowser() {
+  const ua = navigator.userAgent; let tem; let M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || []
+  if (/trident/i.test(M[1])) {
+    tem = /\brv[ :]+(\d+)/g.exec(ua) || []
+    return { name: 'IE', version: (tem[1] || '') }
+  }
+  if (M[1] === 'Chrome') {
+    tem = ua.match(/\bOPR|Edge\/(\d+)/)
+    if (tem != null) {return { name: 'Opera', version: tem[1] }}
+  }
+  M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?']
+  if ((tem = ua.match(/version\/(\d+)/i)) != null) {M.splice(1, 1, tem[1])}
+  return {
+    name: M[0],
+    version: M[1]
+  }
+}


### PR DESCRIPTION
In Safari < 14, the plan selector green area (price) wouldn't go all the way across, so we had a hack in there.
Safari 14 fixed that bug, so it looked fucked up. 