### PR TITLE
Adding app bundles to site association file

### DIFF
--- a/web/src/server/.well-known/apple-app-site-association
+++ b/web/src/server/.well-known/apple-app-site-association
@@ -1,15 +1,20 @@
 {
-	  "applinks": {
-		  "details": [
-			   {
-				 "appIDs": ["Y254DPS4AY.com.bonkeybong.portway"],
-				 "components": [
-				   {
-					  "/": "/d/*",
-					  "comment": "Matches any URL whose path starts with /d/"
-				   }
-				 ]
-			   }
-		   ]
-	   }
-	}
+  "applinks": {
+    "apps": [],
+    "details": [
+        {
+        "appIDs": [
+          "Y254DPS4AY.com.bonkeybong.portway",
+          "Y254DPS4AY.com.bonkeybong.portway.dev",
+          "Y254DPS4AY.com.bonkeybong.portway.staging"
+        ],
+        "components": [
+          {
+          "/": "/d/*",
+          "comment": "Matches any URL whose path starts with /d/"
+          }
+        ]
+        }
+      ]
+    }
+}


### PR DESCRIPTION
I also added the identifiers under Apple's site:

https://developer.apple.com/account/resources/identifiers/list