### PR TITLE
Fixes trial ended linkUrl bug

### DIFF
--- a/api/src/coordinators/email.js
+++ b/api/src/coordinators/email.js
@@ -163,7 +163,7 @@ async function sendTrialEnded(email) {
   await sendSingleRecipientEmail({
     address: email,
     textBody: textBody,
-    linkUrl, linkUrl,
+    linkUrl,
     htmlBody,
     subject
   })


### PR DESCRIPTION
We missed this one too, but that error in the email looks like it's from `sendTrialWillEnd`?