### PR TITLE
Web - temporary updatedAt on projects

### DIFF
--- a/web/src/client/js/actions/document.js
+++ b/web/src/client/js/actions/document.js
@@ -54,14 +54,14 @@ export const createDocument = (projectId, history, body, options = {}) => {
       createField(projectId, data.id, FIELD_TYPES.TEXT, createFieldBody)
     )
 
-    dispatch(Documents.receiveOneCreated(data))
+    dispatch(Documents.receiveOneCreated(projectId, data))
     if (!preventRedirect) {
       history.push({ pathname: `${PATH_PROJECT}/${projectId}/document/${data.id}` })
     }
   }
 }
 
-export const publishDocument = (documentId) => {
+export const publishDocument = (documentId, projectId) => {
   return async (dispatch) => {
     dispatch(Documents.publish(documentId))
     const { data, status } = await add(`v1/documents/${documentId}/publish`)
@@ -69,7 +69,7 @@ export const publishDocument = (documentId) => {
       dispatch(Notifications.create(data.error, NOTIFICATION_TYPES.ERROR, NOTIFICATION_RESOURCE.USER, status))
       return
     }
-    dispatch(Documents.receivePublishedVersion(data))
+    dispatch(Documents.receivePublishedVersion(projectId, data))
   }
 }
 
@@ -83,11 +83,11 @@ export const updateDocument = (projectId, documentId, body) => {
     }
     validationCodes.includes(status) ?
       dispatch(Validation.create('document', data, status)) :
-      dispatch(Documents.receiveOneUpdated(data))
+      dispatch(Documents.receiveOneUpdated(projectId, data))
   }
 }
 
-export const unpublishDocument = (documentId) => {
+export const unpublishDocument = (documentId, projectId) => {
   return async (dispatch) => {
     dispatch(Documents.unpublish(documentId))
     const { data, status } = await add(`v1/documents/${documentId}/unpublish`)
@@ -95,7 +95,7 @@ export const unpublishDocument = (documentId) => {
       dispatch(Notifications.create(data.error, NOTIFICATION_TYPES.ERROR, NOTIFICATION_RESOURCE.USER, status))
       return
     }
-    dispatch(Documents.receiveUnpublishedVersion(data))
+    dispatch(Documents.receiveUnpublishedVersion(projectId, data))
   }
 }
 

--- a/web/src/client/js/actions/index.js
+++ b/web/src/client/js/actions/index.js
@@ -252,14 +252,14 @@ export const Documents = {
   receiveListError: makeActionCreator(ActionTypes.RECEIVE_DOCUMENTS_ERROR, 'projectId'),
   receiveOne: makeActionCreator(ActionTypes.RECEIVE_DOCUMENT, 'data'),
   receiveError: makeActionCreator(ActionTypes.RECEIVE_DOCUMENT_ERROR, 'documentId'),
-  receiveOneCreated: makeActionCreator(ActionTypes.RECEIVE_CREATED_DOCUMENT, 'data'),
-  receiveOneUpdated: makeActionCreator(ActionTypes.RECEIVE_UPDATED_DOCUMENT, 'data'),
-  receivePublishedVersion: makeActionCreator(ActionTypes.RECEIVE_PUBLISHED_DOCUMENT, 'data'),
+  receiveOneCreated: makeActionCreator(ActionTypes.RECEIVE_CREATED_DOCUMENT, 'projectId', 'data'),
+  receiveOneUpdated: makeActionCreator(ActionTypes.RECEIVE_UPDATED_DOCUMENT, 'projectId', 'data'),
+  receivePublishedVersion: makeActionCreator(ActionTypes.RECEIVE_PUBLISHED_DOCUMENT, 'projectId', 'data'),
   requestList: makeActionCreator(ActionTypes.REQUEST_DOCUMENTS, 'projectId'),
   requestOne: makeActionCreator(ActionTypes.REQUEST_DOCUMENT, 'documentId'),
   update: makeActionCreator(ActionTypes.INITIATE_DOCUMENT_UPDATE, 'projectId', 'documentId', 'data'),
   unpublish: makeActionCreator(ActionTypes.INITIATE_DOCUMENT_UNPUBLISH, 'documentId'),
-  receiveUnpublishedVersion: makeActionCreator(ActionTypes.RECEIVE_UNPUBLISHED_DOCUMENT, 'data'),
+  receiveUnpublishedVersion: makeActionCreator(ActionTypes.RECEIVE_UNPUBLISHED_DOCUMENT, 'projectId', 'data'),
   initiateSearch: makeActionCreator(ActionTypes.INITIATE_DOCUMENT_SEARCH, 'value'),
   receiveSearchResults: makeActionCreator(ActionTypes.RECEIVE_DOCUMENT_RESULTS, 'data')
 }

--- a/web/src/client/js/components/Dashboard/DashboardContainer.js
+++ b/web/src/client/js/components/Dashboard/DashboardContainer.js
@@ -24,6 +24,11 @@ const DashboardContainer = ({ organizationData, removeProject, uiConfirm, sortPr
     sortProjects(sortBy, sortMethod)
   }, [sortBy, sortMethod, sortProjects])
 
+  // do an initial sort
+  useEffect(() => {
+    sortProjects(sortBy, sortMethod)
+  }, [])
+
   const { data: { projects }, loading } = useDataService(dataMapper.projects.list(page, sortBy, sortMethod), [sortBy, sortMethod])
   const { data: organization } = useDataService(dataMapper.organizations.current())
   const history = useHistory()

--- a/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
+++ b/web/src/client/js/components/DocumentToolbar/DocumentToolbarContainer.js
@@ -44,7 +44,7 @@ const DocumentToolbarContainer = ({
     )
     const options = {
       confirmedLabel: strings.PUBLISH_CONFIRMATION_LABEL,
-      confirmedAction: () => { publishDocument(document.id) }
+      confirmedAction: () => { publishDocument(document.id, projectId) }
     }
     uiConfirm({ message, options })
   }
@@ -70,7 +70,7 @@ const DocumentToolbarContainer = ({
     )
     const options = {
       confirmedLabel: strings.UNPUBLISH_CONFIRMATION_LABEL,
-      confirmedAction: () => { unpublishDocument(document.id) },
+      confirmedAction: () => { unpublishDocument(document.id, projectId) },
       theme: 'danger'
     }
     uiConfirm({ message, options })

--- a/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
+++ b/web/src/client/js/components/DocumentsList/DocumentsListContainer.js
@@ -114,7 +114,7 @@ const DocumentsListContainer = ({
       </>
     )
     const options = {
-      confirmedAction: () => { unpublishDocument(document.id) },
+      confirmedAction: () => { unpublishDocument(document.id, projectId) },
       confirmedLabel: strings.UNPUBLISH_CONFIRMATION_LABEL,
       theme: 'danger'
     }

--- a/web/src/client/js/reducers/documents.js
+++ b/web/src/client/js/reducers/documents.js
@@ -1,4 +1,5 @@
 import { ActionTypes } from '../actions'
+import moment from 'moment'
 
 const initialState = {
   currentDocumentId: null,
@@ -192,7 +193,7 @@ export const documents = (state = initialState, action) => {
     case ActionTypes.RECEIVE_UPDATED_FIELD:
     case ActionTypes.REMOVE_FIELD: {
       const documentToUpdate = { ...state.projectDocumentsById[action.projectId][action.documentId] }
-      documentToUpdate.updatedAt = Date.now()
+      documentToUpdate.updatedAt = moment().toISOString()
       const project = { ...state.projectDocumentsById[action.projectId], [action.documentId]: documentToUpdate }
       const projectDocumentsById = { ...state.projectDocumentsById, [action.projectId]: project }
       return {

--- a/web/src/client/js/reducers/projects.js
+++ b/web/src/client/js/reducers/projects.js
@@ -1,5 +1,6 @@
 import { ActionTypes } from '../actions'
 import { QUERY_PARAMS } from 'Shared/constants'
+import moment from 'moment'
 
 const initialState = {
   sortBy: 'createdAt',
@@ -98,7 +99,7 @@ export const projects = (state = initialState, action) => {
       return { ...state, projectsById, projectIdsByPage }
     }
     case ActionTypes.SORT_PROJECTS: {
-      if (action.sortBy !== state.sortBy || action.sortMethod !== state.sortMethod) {
+      if (true) {
         return {
           ...state,
           projectIdsByPage: {},
@@ -127,6 +128,23 @@ export const projects = (state = initialState, action) => {
       return {
         ...state,
         exportUrlsById: { ...state.exportUrlsById, [action.projectId]: null }
+      }
+    }
+    // When fields are added/updated/removed, adjust updatedAt on the parent project
+    // accordingly, only client-side... next request for document will get the
+    // right date
+    case ActionTypes.RECEIVE_CREATED_FIELD:
+    case ActionTypes.RECEIVE_UPDATED_FIELD:
+    case ActionTypes.REMOVE_FIELD: 
+    case ActionTypes.RECEIVE_CREATED_DOCUMENT:
+    case ActionTypes.RECEIVE_UPDATED_DOCUMENT:
+    case ActionTypes.REMOVE_DOCUMENT: {
+      const projectToUpdate = { ...state.projectsById[action.projectId] }
+      projectToUpdate.updatedAt = moment().toISOString()
+      const projectsById = { ...state.projectsById, [action.projectId]: projectToUpdate }
+      return {
+        ...state,
+        projectsById
       }
     }
     default:

--- a/web/src/client/js/reducers/projects.js
+++ b/web/src/client/js/reducers/projects.js
@@ -99,15 +99,13 @@ export const projects = (state = initialState, action) => {
       return { ...state, projectsById, projectIdsByPage }
     }
     case ActionTypes.SORT_PROJECTS: {
-      if (true) {
-        return {
-          ...state,
-          projectIdsByPage: {},
-          totalPages: null,
-          sortBy: action.sortBy,
-          sortMethod: action.sortMethod,
-          loading: { ...state.loading, byPage: {} }
-        }
+      return {
+        ...state,
+        projectIdsByPage: {},
+        totalPages: null,
+        sortBy: action.sortBy,
+        sortMethod: action.sortMethod,
+        loading: { ...state.loading, byPage: {} }
       }
       return state
     }


### PR DESCRIPTION
- when docs and fields are created, updated, deleted, parent project gets updatedAt set in client data
- had to trigger an initial sort in the dashboard container, and remove a sort conditional in the projects reducer, which seems to be ok, but worth some thorough testing
