### PR TITLE
save most recent db jobs image in kube config

### DIFF
--- a/kubernetes/jobs/databaseJobs.yaml
+++ b/kubernetes/jobs/databaseJobs.yaml
@@ -16,8 +16,8 @@ spec:
       - name: regcred
       containers:
       - name: portway-db
-        image: "bonkeybong/portway_db_jobs:master-59db7e2"
-        args: ["documentSlugs"]
+        image: "bonkeybong/portway_db_jobs:master-31969aa"
+        args: ["setDeletedRecords"]
         env:
         - name: DB_HOST
           valueFrom:


### PR DESCRIPTION
Committing this so we don't need to go look up the tag if we need to run any of the db jobs.