### PR TITLE
Only send "trial will end" email to trialing users

### DIFF
--- a/api/src/coordinators/stripeEvent.js
+++ b/api/src/coordinators/stripeEvent.js
@@ -5,7 +5,7 @@ import emailCoordinator from '../coordinators/email'
 import logger from '../integrators/logger'
 import { LOG_LEVELS } from '../constants/logging'
 import slackIntegrator from '../integrators/slack'
-import { STRIPE_STATUS } from '../constants/plans'
+import { STRIPE_STATUS, ORG_SUBSCRIPTION_STATUS } from '../constants/plans'
 
 async function handleEvent(event) {
   const eventData = event.data.object
@@ -63,7 +63,9 @@ async function handleEvent(event) {
       }
       break
     case 'customer.subscription.trial_will_end':
-      emailCoordinator.sendTrialWillEnd(customer.email)
+      if (org.subscriptionStatus === ORG_SUBSCRIPTION_STATUS.TRIALING) {
+        emailCoordinator.sendTrialWillEnd(customer.email)
+      }
       break
   }
   //update cached subscription status on org, we want to do this for all current events

--- a/api/src/coordinators/stripeEvent.js
+++ b/api/src/coordinators/stripeEvent.js
@@ -63,6 +63,7 @@ async function handleEvent(event) {
       }
       break
     case 'customer.subscription.trial_will_end':
+      // only send to users currently trialing
       if (org.subscriptionStatus === ORG_SUBSCRIPTION_STATUS.TRIALING) {
         emailCoordinator.sendTrialWillEnd(customer.email)
       }


### PR DESCRIPTION
As the title says. Fixes a scenario where entering cc info and upgrading seats while on the trial would trigger both a "payment success" email and a "trial will end" email