### PR TITLE
track signup source on org

### DIFF
--- a/api/src/controllers/signup.js
+++ b/api/src/controllers/signup.js
@@ -11,7 +11,7 @@ const signupPayloadSchema = Joi.compile({
   email: Joi.string()
     .email()
     .required(),
-  source: Joi.string().optional()
+  source: Joi.string().allow('')
 })
 
 const signupController = function(router) {
@@ -27,9 +27,10 @@ const signupController = function(router) {
 
 const signUp = async function(req, res, next) {
   const { name, email, source } = req.body
+  const plainSource = decodeURIComponent(source)
 
   try {
-    await signUpCoordinator.createUserAndOrganization(name, email, source)
+    await signUpCoordinator.createUserAndOrganization(name, email, plainSource)
     res.status(204).send()
   } catch (e) {
     next(e)

--- a/api/src/controllers/signup.js
+++ b/api/src/controllers/signup.js
@@ -10,7 +10,8 @@ const signupPayloadSchema = Joi.compile({
   name: Joi.string().required(),
   email: Joi.string()
     .email()
-    .required()
+    .required(),
+  source: Joi.string().optional()
 })
 
 const signupController = function(router) {
@@ -25,10 +26,10 @@ const signupController = function(router) {
 }
 
 const signUp = async function(req, res, next) {
-  const { name, email } = req.body
+  const { name, email, source } = req.body
 
   try {
-    await signUpCoordinator.createUserAndOrganization(name, email)
+    await signUpCoordinator.createUserAndOrganization(name, email, source)
     res.status(204).send()
   } catch (e) {
     next(e)

--- a/api/src/coordinators/signUp.js
+++ b/api/src/coordinators/signUp.js
@@ -15,7 +15,13 @@ import { LOG_LEVELS } from '../constants/logging'
 
 const { CLIENT_URL } = process.env
 
-async function createUserAndOrganization(name, email) {
+/**
+ * 
+ * @param {String} name the user's name, all one string in whatever format they choose
+ * @param {String} email the user's email address. Must be valid email to verify and use account
+ * @param {String} source (optional) a string indicating where the user signed up from
+ */
+async function createUserAndOrganization(name, email, source) {
   const existingUser = await BusinessUser.findByEmail(email)
 
   if (existingUser) {
@@ -23,7 +29,12 @@ async function createUserAndOrganization(name, email) {
   }
 
   const organizationName = `${name}'s Organization`
-  const organization = await BusinessOrganization.create({ name: organizationName })
+
+  const newOrg = { name: organizationName }
+  if (source) {
+    newOrg.source = source
+  }
+  const organization = await BusinessOrganization.create(newOrg)
 
   const createdUser = await userCoordinator.createPendingUser(
     email, name, organization.id, ORGANIZATION_ROLE_IDS.OWNER

--- a/api/src/coordinators/signUp.js
+++ b/api/src/coordinators/signUp.js
@@ -68,7 +68,8 @@ async function createUserAndOrganization(name, email, source) {
   await emailCoordinator.sendSignupVerification(linkUrl, createdUser.email)
 
   // not awaiting this, sends a notification to slack channel
-  slackIntegrator.sendNotification(`${email} has signed up for Portway`)
+  const fromSource = source ? ` from ${source}` : ''
+  slackIntegrator.sendNotification(`${email} has signed up for Portway${fromSource}`)
 }
 
 export default {

--- a/api/src/coordinators/stripeEvent.js
+++ b/api/src/coordinators/stripeEvent.js
@@ -24,7 +24,8 @@ async function handleEvent(event) {
       // No need to await webhook
       emailCoordinator.sendPaymentSuccess(customer.email, eventData.amount)
       // not awaiting this, sends a notification to slack channel
-      slackIntegrator.sendNotification(`:moneybag: ${customer.email} was successfully charged :moneybag:`)
+      const fromSource = org.source ? ` (source: ${source})` : ''
+      slackIntegrator.sendNotification(`:moneybag: ${customer.email} was successfully charged :moneybag:${fromSource}`)
       break
     }
     case 'customer.subscription.deleted': {

--- a/api/src/db/migrations/20210203160728-add-source-to-organization.js
+++ b/api/src/db/migrations/20210203160728-add-source-to-organization.js
@@ -1,0 +1,9 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Organizations', 'source', Sequelize.STRING)
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Organizations', 'source')
+  }
+};

--- a/api/src/db/models/organization.js
+++ b/api/src/db/models/organization.js
@@ -21,7 +21,8 @@ module.exports = (sequelize, DataTypes) => {
       plan: DataTypes.ENUM(Object.keys(PLANS)),
       subscriptionStatus: DataTypes.STRING,
       canceledAt: DataTypes.DATE,
-      introProjectId: DataTypes.INTEGER
+      introProjectId: DataTypes.INTEGER,
+      source: DataTypes.STRING
     },
     {
       paranoid: true

--- a/web/src/server/controllers/sign-up.js
+++ b/web/src/server/controllers/sign-up.js
@@ -21,21 +21,29 @@ const footerLinks = {
 }
 
 const SignUpController = function(router) {
+  // Initial sign up form. Posts to /registration route and then redirects to /processing
   router.get('/', (req, res) => {
-    res.render('user/sign-up', renderBundles(req, 'Sign up', 'signup', footerLinks))
+    const { source } = req.query
+    res.render('user/sign-up', { ...renderBundles(req, 'Sign up', 'signup', footerLinks), source })
   })
 
+  // After initial signup, this route renders "Verify email address" static page
   router.get('/processing', (req, res) => {
     res.render('user/processing', renderBundles(req, 'Processing', 'index', footerLinks))
   })
 
+  // This is the initial signup route, when a user first submits their name and email to create
+  // a Portway account
   router.post('/registration', registerOrganization)
 
+  // This is the page rendered for the user to set their initial password _after_ they have verified
+  // their email
   router.get('/registration/complete', async (req, res) => {
     const { token } = req.query
     res.render('user/registration', { ...renderBundles(req, 'Registration', 'registration', footerLinks), token })
   })
 
+  // Set initial password form submission
   router.post('/registration/complete', completeRegistration)
 }
 
@@ -44,7 +52,7 @@ const registerOrganization = async (req, res) => {
     return res.status(403).send('Signup disabled')
   }
 
-  const { name, email } = req.body
+  const { name, email, source } = req.body
 
   try {
     await API.send({
@@ -52,7 +60,8 @@ const registerOrganization = async (req, res) => {
       method: 'POST',
       data: {
         name,
-        email
+        email,
+        source
       }
     })
   } catch ({ response }) {

--- a/web/src/server/views/partials/sign-up.ejs
+++ b/web/src/server/views/partials/sign-up.ejs
@@ -1,4 +1,5 @@
 <form class="login-form" action="/sign-up/registration" method="post">
+  <input type="hidden" name="source" value="<%= source %>" />
   <div class="field-container">
     <div class="field">
       <label class="label" for="name">Your name</label>


### PR DESCRIPTION
Works in conjunction with https://github.com/BonkeyBong/portway-website/pull/41

- The API and the web service signup form support a "source" attribute which is pulled from the query parameter "source" on the signup page. The parameter is optional.
- The source is stored on the organization
- Added source to some slack notifications, including trial signup and payment
- Ability to link directly to signup form with custom sources: `https://portway.app/signup?source=twitter`