### PR TITLE
create magic field v. carefully

### DIFF
--- a/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsComponent.js
@@ -11,7 +11,7 @@ import FieldImageComponent from 'Components/FieldImage/FieldImageComponent'
 import FieldDateComponent from 'Components/FieldDate/FieldDateComponent'
 import FieldFileComponent from 'Components/FieldFile/FieldFileComponent'
 
-const DocumentFieldsComponent = ({
+const DocumentFieldsComponent = React.forwardRef(({
   createdFieldId,
   createFieldHandler,
   disabled,
@@ -24,7 +24,7 @@ const DocumentFieldsComponent = ({
   fieldsUpdating,
   isPublishing,
   readOnly
-}) => {
+}, ref) => {
   const [settingsForField, setSettingsForField] = useState(null)
   const hasOnlyOneTextField = fields.length === 1 && fields[0].type === FIELD_TYPES.TEXT
 
@@ -169,13 +169,13 @@ const DocumentFieldsComponent = ({
     'document__fields--disabled': isPublishing || disabled
   })
   return (
-    <div className={fieldsClasses}>
+    <div ref={ref} className={fieldsClasses}>
       <ol className="document__fields-list">
         {renderFields()}
       </ol>
     </div>
   )
-}
+})
 
 DocumentFieldsComponent.propTypes = {
   createdFieldId: PropTypes.number,

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -28,6 +28,7 @@ const DocumentFieldsContainer = ({
 }) => {
   const { projectId, documentId } = useParams()
   const fieldKeys = useRef([])
+  const docAreaRef = useRef()
   const { data: foundFields } = useDataService(dataMapper.fields.list(documentId), [documentId])
   const { data: userProjectAssignments = {}, loading: assignmentLoading } = useDataService(dataMapper.users.currentUserProjectAssignments())
   const activeUsers = activeDocumentUsers[documentId]
@@ -68,6 +69,28 @@ const DocumentFieldsContainer = ({
       })
     }
   }, [documentReadOnlyMode, fields, createField, documentId, projectId])
+
+  const createTextFieldForExistingEmptyDocumentHandler = useCallback(() => {
+
+  })
+
+  // This listener handles the scenario where a document has already been created
+  // and has no fields. The document create action creates a text field, so the user would
+  // need to delete all the fields, or create a document via the API in order to have no fields
+  useEffect(() => {
+    if (
+      docAreaRef && docAreaRef.current && 
+      !hasFields && foundFields && Object.keys(foundFields).length === 0
+    ) {
+      docAreaRef.current.addEventListener('click', createTextFieldHandler, false)
+      return function cleanup() {
+        docAreaRef.current.removeEventListener('click', createTextFieldHandler, false)
+      }
+    }
+  // Check hasFields and foundFields. hasFields provides an already computed quick check, and
+  // foundFields is the value from the redux store. We want to explicitly look at foundFields to
+  // determine 1) have the fields loaded 2) are there any fields
+  }, [hasFields, foundFields])
 
   useEffect(() => {
     // If we are in a new document, or a document with one blank text field,
@@ -124,6 +147,7 @@ const DocumentFieldsContainer = ({
 
   return (
     <DocumentFieldsComponent
+      ref={docAreaRef}
       activeUsers={activeUsers}
       createFieldHandler={createTextFieldHandler}
       createdFieldId={createdFieldId}

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -42,8 +42,8 @@ const DocumentFieldsContainer = ({
   }
 
   const sortedFields = useMemo(() => {
-    // Sort the fields every re-render
     fieldKeys.current = Object.keys(fields)
+
     const fieldMapTemp = fieldKeys.current.map((fieldId) => {
       return fields[fieldId]
     })
@@ -57,7 +57,7 @@ const DocumentFieldsContainer = ({
   const hasOnlyOneTextField = hasFields && sortedFields.length === 1 && fields[sortedFields[0].id].type === FIELD_TYPES.TEXT
 
   const createTextFieldHandler = useCallback(() => {
-    if (!documentReadOnlyMode) {
+    if (!documentReadOnlyMode && parseInt(documentId) && parseInt(projectId)) {
       // This is triggered by the Big Invisible Button™
       // It should append a new text field to the end of the document, making it seem as though the
       // user is clicking to continue the document body

--- a/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
+++ b/web/src/client/js/components/DocumentFields/DocumentFieldsContainer.js
@@ -70,15 +70,6 @@ const DocumentFieldsContainer = ({
   }, [documentReadOnlyMode, fields, createField, documentId, projectId])
 
   useEffect(() => {
-    if (!hasFields) {
-      document.addEventListener('click', createTextFieldHandler, false)
-      return function cleanup() {
-        document.removeEventListener('click', createTextFieldHandler, false)
-      }
-    }
-  }, [createTextFieldHandler, hasFields])
-
-  useEffect(() => {
     // If we are in a new document, or a document with one blank text field,
     // clicking anywhere within the document should focus that field
     function documentClickHandler(e) {


### PR DESCRIPTION
Steps to reproduce issue:
- Go to portway
- Navigate to a project. Do not select a document. Do not pass go. Do not collect $200
- Click in the blank document area
- Now click on a document
- The document will be disabled without this PR

Things this PR fixes:
- cannot invoke create field without a document ID and project ID
- Fixes click handler to add a field to an empty document by scoping it to document area only _and_ only fires when fields have been loaded and are empty