### PR TITLE
fixing zendesk integration

### DIFF
--- a/web/src/server/controllers/support.js
+++ b/web/src/server/controllers/support.js
@@ -6,10 +6,16 @@ const { SUPPORT_FORM_SUBMIT_ORIGIN } = process.env
 const SupportController = function(router) {
   router.post('/', async (req, res) => {
     const { email, message, name, subject, company } = req.body
+
     slack.sendNotification(
       `:question: Support :question: \n Email: ${email} \n Name: ${name} \n Company: ${company} \n Subject: ${subject} \n Message: ${message}`
     )
-    await addRequest(email, message, company, name, subject)
+    try {
+      const requestSubject = subject || 'Portway Request'
+      await addRequest(email, message, company, name, requestSubject)
+    } catch(e) {
+      console.error(e)
+    }
     // If we're getting hit from the external website, do a redirect
     if (req.get('origin') === SUPPORT_FORM_SUBMIT_ORIGIN) {
       const base = SUPPORT_FORM_SUBMIT_ORIGIN

--- a/web/src/server/libs/zendesk.js
+++ b/web/src/server/libs/zendesk.js
@@ -2,11 +2,11 @@
 import axios from 'axios'
 
 const ZENDESK_API_TOKEN = process.env.ZENDESK_API_TOKEN
-const ZENDESK_REQUEST_ENDPOINT = 'https://portway.zendesk.com/api/v2/requests.json'
+const ZENDESK_REQUEST_ENDPOINT = 'https://portway.zendesk.com/api/v2/requests'
 
-export default function addRequest(email, message, company, name, subject) {
+export default async function addRequest(email, message, company, name, subject) {
   try {
-    axios({
+    await axios({
       method: 'post',
       url: ZENDESK_REQUEST_ENDPOINT,
       data: {
@@ -16,15 +16,20 @@ export default function addRequest(email, message, company, name, subject) {
           comment: { body: `Company: ${company}\n\n${message}` }
         }
       },
-      auth: {
-        username: zendeskToken(email)
+      headers: {
+        'Authorization': `Basic ${zendeskToken(email)}`
       }
     })
   } catch (e) {
-    console.error(e)
+    if (typeof e.toJSON === 'function') {
+      console.error(e.toJSON())
+    } else {
+      console.error(e)
+    }
   }
 }
 
 function zendeskToken(email) {
-  return `${email}/token:${ZENDESK_API_TOKEN}`
+  const buffer = Buffer.from(`${email}/token:${ZENDESK_API_TOKEN}`)
+  return buffer.toString('base64')
 }


### PR DESCRIPTION
API now requires the subject to not be an empty string, which was not a previous requirement. Holy breaking changes batman.

Also I rewrote the auth to match their docs thinking that was the problem but it works either way. But this way is kewl.