### PR TITLE
option to set markUpdated on project delete

### DIFF
--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -66,6 +66,7 @@ const updateDocumentField = async function(fieldId, documentId, orgId, body, fil
 /*
  * options = {
  *   deletePublished: true // ignores published status of field when deleting field
+ *   markUpdated: true/false // whether to mark parent document and project as updated
  * }
  */
 const removeDocumentField = async function(fieldId, documentId, orgId, options) {

--- a/api/src/coordinators/projectCrud.js
+++ b/api/src/coordinators/projectCrud.js
@@ -15,9 +15,10 @@ const createProject = async (projectBody, creatorUserId, orgId) => {
 }
 
 const deleteById = async (projectId, orgId) => {
-  await BusinessProject.deleteById(projectId, orgId)
+
   await BusinessProjectUser.removeAllUsersFromProject(projectId, orgId)
   await documentCoordinator.deleteAllForProject(projectId, orgId)
+  await BusinessProject.deleteById(projectId, orgId)
 }
 
 export default {


### PR DESCRIPTION
Since the markUpdated() is async and not awaited, it can trigger after the project or document has been deleted. When deleting a project it makes a bunch of unnecessary updates (because the resources are being deleted!). Added option to override the "markUpdated" functionality to all the functions.