### PR TITLE
delete stripe customer when deleting unverified orgs

### DIFF
--- a/api/src/controllers/admin.js
+++ b/api/src/controllers/admin.js
@@ -153,7 +153,7 @@ const deleteUnverifiedOrgs = async function(req, res, next) {
     const unverifiedUsers = await BusinessUser.findAllUnverifiedOwners()
     let removedOrgsCount = 0
     for (const user of unverifiedUsers) {
-      await organizationCoordinator.removeAllOrgData(user.orgId)
+      await organizationCoordinator.deleteOrg(user.orgId)
       removedOrgsCount += 1
     }
     res.status(200).send({ data: { removedOrgsCount } })

--- a/api/src/coordinators/organization.js
+++ b/api/src/coordinators/organization.js
@@ -71,10 +71,18 @@ const deleteCanceledOrg = async function(orgId) {
   await organizationCoordinator.removeAllOrgData(orgId)
 }
 
+// Permanently deletes an org and associated resources
+const deleteOrg = async function (orgId) {
+  const org = await BusinessOrganization.findById(orgId)
+  await stripeIntegrator.deleteCustomer(org.stripeId)
+  await organizationCoordinator.removeAllOrgData(orgId)
+}
+
 const organizationCoordinator = {
   updateById,
   removeAllOrgData,
-  deleteCanceledOrg
+  deleteCanceledOrg,
+  deleteOrg
 }
 
 export default organizationCoordinator

--- a/api/src/coordinators/organization.test-u.js
+++ b/api/src/coordinators/organization.test-u.js
@@ -175,6 +175,7 @@ describe('organization coordinator', () => {
   describe('#deleteOrg', () => {
     beforeAll(async () => {
       BusinessOrganization.findById.mockReturnValueOnce({ id: orgId, stripeId })
+      organizationCoordinator.removeAllOrgData.mockClear()
       await organizationCoordinator.deleteOrg(orgId)
     })
 

--- a/api/src/coordinators/organization.test-u.js
+++ b/api/src/coordinators/organization.test-u.js
@@ -174,6 +174,7 @@ describe('organization coordinator', () => {
 
   describe('#deleteOrg', () => {
     beforeAll(async () => {
+      BusinessOrganization.findById.mockClear()
       BusinessOrganization.findById.mockReturnValueOnce({ id: orgId, stripeId })
       organizationCoordinator.removeAllOrgData.mockClear()
       await organizationCoordinator.deleteOrg(orgId)

--- a/api/src/coordinators/organization.test-u.js
+++ b/api/src/coordinators/organization.test-u.js
@@ -171,4 +171,27 @@ describe('organization coordinator', () => {
       })
     })
   })
+
+  describe('#deleteOrg', () => {
+    beforeAll(async () => {
+      BusinessOrganization.findById.mockReturnValueOnce({ id: orgId, stripeId })
+      await organizationCoordinator.deleteOrg(orgId)
+    })
+
+    it('should call BusinessOrganization.findById with orgId', () => {
+      expect(BusinessOrganization.findById.mock.calls.length).toBe(1)
+      expect(BusinessOrganization.findById.mock.calls[0][0]).toEqual(orgId)
+    })
+
+    it('should call stripeIntegrator.deleteCustomer', () => {
+      expect(stripeIntegrator.deleteCustomer.mock.calls.length).toBe(1)
+      expect(stripeIntegrator.deleteCustomer.mock.calls[0][0]).toEqual(stripeId)
+    })
+
+    it('should call organizationCoordinator.removeAllOrgData with the passed in org id', () => {
+      expect(organizationCoordinator.removeAllOrgData.mock.calls.length).toBe(1)
+      expect(organizationCoordinator.removeAllOrgData.mock.calls[0][0]).toBe(orgId)
+    })
+
+  })
 })

--- a/api/src/integrators/__mocks__/stripe.js
+++ b/api/src/integrators/__mocks__/stripe.js
@@ -6,7 +6,8 @@ export default {
   getCustomer: jest.fn(() => getGenericStripeCustomerData()),
   updateCustomer: jest.fn(() => getGenericStripeCustomerData()),
   cancelSubscription: jest.fn(),
-  cancelSubscriptionAtPeriodEnd: jest.fn()
+  cancelSubscriptionAtPeriodEnd: jest.fn(),
+  deleteCustomer: jest.fn()
 }
 
 

--- a/api/src/integrators/stripe.js
+++ b/api/src/integrators/stripe.js
@@ -121,6 +121,11 @@ const cancelSubscriptionAtPeriodEnd = function(subscriptionId) {
   return stripe.subscriptions.update(subscriptionId, { cancel_at_period_end: true })
 }
 
+// Removes customer + active subscriptions. Cannot be undone, but Stripe preserves history
+const deleteCustomer = function(customerId) {
+  return stripe.customers.del(customerId)
+}
+
 
 export default {
   createCustomer,
@@ -129,5 +134,6 @@ export default {
   createOrUpdateSubscription,
   constructWebhookEvent,
   cancelSubscription,
-  cancelSubscriptionAtPeriodEnd
+  cancelSubscriptionAtPeriodEnd,
+  deleteCustomer
 }


### PR DESCRIPTION
Lots of 404s on stripe webhooks and they keep retrying because we deleted the unverified users but not the stripe customer

Oops branched off #865 so that should get reviewed first