### PR TITLE
image field metadata

### DIFF
--- a/api/src/constants/fieldTypes.js
+++ b/api/src/constants/fieldTypes.js
@@ -21,4 +21,10 @@ export const MAX_NUMBER_PRECISION = 15
 // 100 Megabytes
 export const MAX_FILE_SIZE_BYTES = 10e7
 
+export const IMAGE_ALIGNMENT_OPTIONS = {
+  LEFT: 'left',
+  CENTER: 'center',
+  RIGHT: 'right'
+}
+
 export default { FIELD_TYPES, FIELD_TYPE_MODELS }

--- a/api/src/constants/resourcePublicFields.js
+++ b/api/src/constants/resourcePublicFields.js
@@ -28,7 +28,9 @@ const FIELD_PUBLIC_FIELDS = [
   'type',
   'order',
   'meta',
-  'formats'
+  'formats',
+  'alignment',
+  'alt'
 ].concat(globalPublicFields)
 
 const PROJECT_USERS_PUBLIC_FIELDS = ['id', 'roleId', 'projectId', 'userId'].concat(globalPublicFields)

--- a/api/src/controllers/documentFields.js
+++ b/api/src/controllers/documentFields.js
@@ -49,7 +49,7 @@ const documentFields = function(router) {
         fileSize: MAX_FILE_SIZE_BYTES
       }
     }).single('file'),
-    validateBody(partialFields(RESOURCE_TYPES.FIELD, 'name', 'value', 'structuredValue'), {
+    validateBody(partialFields(RESOURCE_TYPES.FIELD, 'name', 'value', 'structuredValue', 'alt', 'alignment'), {
       includeDetails: true
     }),
     updatePerm,

--- a/api/src/controllers/payloadSchemas/field.js
+++ b/api/src/controllers/payloadSchemas/field.js
@@ -1,9 +1,9 @@
 import Joi from '@hapi/joi'
-import fieldTypes, { FIELD_TYPES } from '../../constants/fieldTypes'
+import fieldTypes, { FIELD_TYPES, IMAGE_ALIGNMENT_OPTIONS } from '../../constants/fieldTypes'
 
 export const rawSchema = {
   name: Joi.string().max(50),
-  value: Joi.any().when('type', { 
+  value: Joi.any().when('type', {
     switch: [
       { is: FIELD_TYPES.TEXT, then: Joi.string() },
       { is: FIELD_TYPES.STRING, then: Joi.string() },
@@ -15,7 +15,9 @@ export const rawSchema = {
   }).allow(null).allow(''),
   // TODO: probably want a shared json parse validator on structuredValue
   structuredValue: Joi.string().allow(null),
-  type: Joi.number().valid(...Object.values(fieldTypes.FIELD_TYPES)).required()
+  type: Joi.number().valid(...Object.values(fieldTypes.FIELD_TYPES)).required(),
+  alignment: Joi.string().valid(...Object.values(IMAGE_ALIGNMENT_OPTIONS)).allow(null),
+  alt: Joi.string().allow(null).allow('')
 }
 
 export default Joi.compile(rawSchema)

--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -1,5 +1,5 @@
 import BusinessField from '../businesstime/field'
-import { FIELD_TYPES } from '../constants/fieldTypes'
+import { FIELD_TYPES, IMAGE_ALIGNMENT_OPTIONS } from '../constants/fieldTypes'
 import { processMarkdownSync } from './markdown'
 import assetCoordinator from './assets'
 import { callFuncWithArgs } from '../libs/utils'

--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -119,6 +119,7 @@ const getFieldBodyByType = async function(body, documentId, orgId, file) {
         const cleanImageInfo = await sharp(file.path).toFile(cleanFilePath)
         const url = await assetCoordinator.addAssetForDocument(documentId, orgId, { ...file, path: cleanFilePath, size: cleanImageInfo.size })
         fieldBody.value = url
+        fieldBody.meta = { width: cleanImageInfo.width, height: cleanImageInfo.height }
       }
       break
     case FIELD_TYPES.TEXT:

--- a/api/src/db/migrations/20210308204923-add-image-options-to-field.js
+++ b/api/src/db/migrations/20210308204923-add-image-options-to-field.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Fields', 'alignment', Sequelize.STRING)
+    return queryInterface.addColumn('Fields', 'alt', Sequelize.STRING)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Fields', 'alignment')
+    await queryInterface.removeColumn('Fields', 'alt')
+  }
+}

--- a/api/src/db/models/field.js
+++ b/api/src/db/models/field.js
@@ -20,7 +20,22 @@ module.exports = (sequelize, DataTypes) => {
         }
       },
       meta: DataTypes.JSON,
-      formats: DataTypes.JSON
+      formats: DataTypes.JSON,
+      // alignment and alt are specific to image type fields, so we have special getters to omit them if they are set to null 
+      alignment: {
+        type: DataTypes.STRING,
+        get() {
+          if (this.getDataValue('alignment') == null) return
+          return this.getDataValue('alignment')
+        }
+      },
+      alt: {
+        type: DataTypes.STRING,
+        get() {
+          if (this.getDataValue('alt') == null) return
+          return this.getDataValue('alt')
+        }
+      }
     },
     {
       paranoid: true,


### PR DESCRIPTION
- adds original width and height to field meta object when uploading image
- adds alignment and alt field props, settable via api(we'll want to make 'center' default in our UI, not in the API)
- uses special getters to not return anything if alt or alignment are null