### PR TITLE
soft delete project webhooks when soft deleting a project

### DIFF
--- a/api/src/businesstime/webhook.js
+++ b/api/src/businesstime/webhook.js
@@ -82,6 +82,14 @@ async function deleteAllSoftDeletedBefore(timestamp) {
   })
 }
 
+async function deleteAllForProject(projectId, orgId) {
+  const db = getDb()
+
+  return db.model(MODEL_NAME).destroy({
+    where: { projectId, orgId }
+  })
+}
+
 export default {
   create,
   findById,
@@ -89,5 +97,6 @@ export default {
   updateById,
   deleteById,
   deleteAllForOrg,
-  deleteAllSoftDeletedBefore
+  deleteAllSoftDeletedBefore,
+  deleteAllForProject
 }

--- a/api/src/coordinators/projectCrud.js
+++ b/api/src/coordinators/projectCrud.js
@@ -1,5 +1,6 @@
 import BusinessProject from '../businesstime/project'
 import BusinessProjectUser from '../businesstime/projectuser'
+import BusinessWebhook from '../businesstime/webhook'
 import documentCoordinator from './document'
 import { PROJECT_ROLE_IDS } from '../constants/roles'
 
@@ -18,6 +19,7 @@ const deleteById = async (projectId, orgId) => {
 
   await BusinessProjectUser.removeAllUsersFromProject(projectId, orgId)
   await documentCoordinator.deleteAllForProject(projectId, orgId)
+  await BusinessWebhook.deleteAllForProject(projectId, orgId)
   await BusinessProject.deleteById(projectId, orgId)
 }
 


### PR DESCRIPTION
to test:

while on the release branch, add 2 webhooks to a project

delete the project

in the portway-ops repo checkout this branch https://github.com/BonkeyBong/portway-ops/pull/13

in the dbJobs directory, make sure you have an env file with the required data from example.env

`cd dbJobs`
`docker build -t bonkeybong/portway_db_jobs`
`docker run --env-file='.env' bonkeybong/portway_db_jobs softDeleteWebhooks`

the results of the script should include at least 2 updated webhooks (maybe more if you've previously deleted a project locally that had webhooks)

switch to this branch and go through the whole process again
when you run the script you should have 0 updated webhooks, meaning that they got soft deleted along with the project