### PR TITLE
string validation

### DIFF
--- a/api/src/controllers/payloadSchemas/field.js
+++ b/api/src/controllers/payloadSchemas/field.js
@@ -6,7 +6,7 @@ export const rawSchema = {
   value: Joi.any().when('type', {
     switch: [
       { is: FIELD_TYPES.TEXT, then: Joi.string() },
-      { is: FIELD_TYPES.STRING, then: Joi.string() },
+      { is: FIELD_TYPES.STRING, then: Joi.string().max(255) },
       { is: FIELD_TYPES.IMAGE, then: Joi.string() },
       { is: FIELD_TYPES.NUMBER, then: Joi.number().strict() },
       { is: FIELD_TYPES.DATE, then: Joi.date().iso() }

--- a/api/src/coordinators/field.test-u.js
+++ b/api/src/coordinators/field.test-u.js
@@ -153,7 +153,7 @@ describe('fieldCoordinator', () => {
     const fieldId = 999
     const documentId = 0
     const orgId = 111
-    const body = { value: 'some-random-text', orgId: 0 }
+    const body = { value: 'some-random-text' }
     const mockReturnField = { id: fieldId, documentId, orgId, type: FIELD_TYPES.TEXT, value: body.value }
 
     beforeAll(async () => {

--- a/api/src/libs/joiErrorToApiError.js
+++ b/api/src/libs/joiErrorToApiError.js
@@ -1,0 +1,14 @@
+import ono from 'ono'
+import apiErrorTypes from '../constants/apiErrorTypes'
+import PUBLIC_MESSAGES from '../constants/publicMessages'
+
+export default function joiErrorToApiError(error, includeDetails = false) {
+  const apiError = new ono({ code: 400, publicMessage: PUBLIC_MESSAGES.INVALID_PAYLOAD }, error.message)
+
+  if (error.name === 'ValidationError' && includeDetails) {
+    apiError.errorDetails = error.details.map((detail) => { return { message: detail.message, key: detail.context.key } })
+    apiError.errorType = apiErrorTypes.ValidationError
+  }
+
+  return apiError
+}

--- a/api/src/libs/middleware/payloadValidation.js
+++ b/api/src/libs/middleware/payloadValidation.js
@@ -1,6 +1,7 @@
 import ono from 'ono'
 import apiErrorTypes from '../../constants/apiErrorTypes'
 import PUBLIC_MESSAGES from '../../constants/publicMessages'
+import joiErrorToApiError from '../joiErrorToApiError'
 
 // validation occurs on req.body
 export function validateBody(schema, options = {}) {
@@ -20,14 +21,7 @@ export function validateBody(schema, options = {}) {
       req.body = value
       return next()
     }
-
-    const apiError = new ono({ code: 400, publicMessage: PUBLIC_MESSAGES.INVALID_PAYLOAD }, error.message)
-
-    if (error.name === 'ValidationError' && includeDetails) {
-      apiError.errorDetails = error.details.map((detail) => { return { message: detail.message, key: detail.context.key }})
-      apiError.errorType = apiErrorTypes.ValidationError
-    }
-
+    const apiError = joiErrorToApiError(error, includeDetails)
     next(apiError)
   }
 }

--- a/web/src/client/js/actions/field.js
+++ b/web/src/client/js/actions/field.js
@@ -23,13 +23,14 @@ export const createField = (projectId, documentId, fieldType, body) => {
     }
     if (validationCodes.includes(status)) {
       dispatch(Validation.create('field', data, status))
-    } else {
-      dispatch(Fields.receiveOneCreated(projectId, documentId, data))
-      dispatch(Fields.setLastCreatedFieldId(data.id))
-      return data
+      return
     }
+
+    dispatch(Fields.receiveOneCreated(projectId, documentId, data))
+    dispatch(Fields.setLastCreatedFieldId(data.id))
     // emit user sync message
     dispatch(emitFieldChange(data.id, documentId))
+    return data
   }
 }
 
@@ -48,11 +49,16 @@ export const updateField = (projectId, documentId, fieldId, body) => {
       dispatch(Notifications.create(data.error, NOTIFICATION_TYPES.ERROR, NOTIFICATION_RESOURCE.FIELD, status))
       return
     }
-    validationCodes.includes(status) ?
-      dispatch(Validation.create('field', data, status)) :
-      dispatch(Fields.receiveOneUpdated(projectId, documentId, fieldId, data))
+
+    if (validationCodes.includes(status)) {
+      dispatch(Validation.create('field', data, status))
+      return
+    }
+
+    dispatch(Fields.receiveOneUpdated(projectId, documentId, fieldId, data))
     // emit user sync message
     dispatch(emitFieldChange(fieldId, documentId))
+    return data
   }
 }
 

--- a/web/src/client/js/components/DocumentFields/_DocumentField.scss
+++ b/web/src/client/js/components/DocumentFields/_DocumentField.scss
@@ -216,6 +216,18 @@
   }
 }
 
+.document-field__string-status {
+  font-size: 1rem;
+  opacity: 0.5;
+  position: absolute;
+  right: .8rem;
+  top: -4.2rem;
+  @include media('>=medium') {
+    right: var(--icon-margin);
+    top: var(--icon-margin);
+  }
+}
+
 // This is the invisible big button at the bottom of the document that only
 // appears if the last field is NOT a text field
 // This is for tricky "pretend" document body behavior

--- a/web/src/client/js/components/FieldString/FieldStringComponent.js
+++ b/web/src/client/js/components/FieldString/FieldStringComponent.js
@@ -38,7 +38,8 @@ const FieldStringComponent = ({
       placeholder="A string value..."
       readOnly={readOnly}
       ref={focusRef}
-      type="text" />
+      type="text"
+      maxLength="255" />
   )
 }
 

--- a/web/src/client/js/components/FieldString/FieldStringComponent.js
+++ b/web/src/client/js/components/FieldString/FieldStringComponent.js
@@ -2,6 +2,8 @@ import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { FIELD_TYPES } from 'Shared/constants'
 
+const STRING_MAX_LENGTH = 255
+
 const FieldStringComponent = ({
   autoFocusElement,
   id,
@@ -20,26 +22,29 @@ const FieldStringComponent = ({
     }
   }, [autoFocusElement])
   return (
-    <input
-      // eslint-disable-next-line jsx-a11y/no-autofocus
-      autoFocus={autoFocusElement}
-      className="document-field__string"
-      value={value || ''}
-      onBlur={(e) => { onBlur(id, type, documentId) }}
-      onChange={(e) => {
-        onChange(id, e.target.value)
-      }}
-      onFocus={(e) => {
-        if (!readOnly) {
-          onFocus(id, type, documentId)
-          e.target.select()
-        }
-      }}
-      placeholder="A string value..."
-      readOnly={readOnly}
-      ref={focusRef}
-      type="text"
-      maxLength="255" />
+    <>
+      <input
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocusElement}
+        className="document-field__string"
+        value={value || ''}
+        onBlur={(e) => { onBlur(id, type, documentId) }}
+        onChange={(e) => {
+          onChange(id, e.target.value)
+        }}
+        onFocus={(e) => {
+          if (!readOnly) {
+            onFocus(id, type, documentId)
+            e.target.select()
+          }
+        }}
+        placeholder="A string value..."
+        readOnly={readOnly}
+        ref={focusRef}
+        type="text"
+        maxLength={STRING_MAX_LENGTH} />
+      <span className="document-field__string-status">{focusRef.current && focusRef.current.value.length} / {STRING_MAX_LENGTH}</span>
+    </>
   )
 }
 

--- a/web/src/client/js/components/FieldString/FieldStringComponent.js
+++ b/web/src/client/js/components/FieldString/FieldStringComponent.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { FIELD_TYPES } from 'Shared/constants'
 
@@ -15,12 +15,25 @@ const FieldStringComponent = ({
   onFocus,
   readOnly
 }) => {
+  const [counterVisible, setCounterVisible] = useState(false)
   const focusRef = useRef()
+
   useEffect(() => {
     if (autoFocusElement && focusRef.current) {
       focusRef.current.focus()
     }
   }, [autoFocusElement])
+
+  useEffect(() => {
+    let interval = null
+    if (counterVisible) {
+      interval = setInterval(() => {
+        setCounterVisible(false)
+      }, 5000)
+    }
+    return () => { clearInterval(interval) }
+  }, [counterVisible])
+
   return (
     <>
       <input
@@ -30,6 +43,7 @@ const FieldStringComponent = ({
         value={value || ''}
         onBlur={(e) => { onBlur(id, type, documentId) }}
         onChange={(e) => {
+          setCounterVisible(true)
           onChange(id, e.target.value)
         }}
         onFocus={(e) => {
@@ -43,7 +57,13 @@ const FieldStringComponent = ({
         ref={focusRef}
         type="text"
         maxLength={STRING_MAX_LENGTH} />
-      <span className="document-field__string-status">{focusRef.current && focusRef.current.value.length} / {STRING_MAX_LENGTH}</span>
+      <span className="document-field__string-status">
+        {counterVisible &&
+        <>
+        {focusRef.current && focusRef.current.value.length} / {STRING_MAX_LENGTH}
+        </>
+        }
+      </span>
     </>
   )
 }

--- a/web/src/client/js/reducers/validation.js
+++ b/web/src/client/js/reducers/validation.js
@@ -20,7 +20,6 @@ export const validation = (state = initialState, action) => {
     case ActionTypes.CREATE_VALIDATION_ERRORS: {
       const resource = action.resource
       const errorsByField = groupBy(action.data.errorDetails, 'key')
-      console.log(errorsByField)
       return {
         ...state,
         [resource]: errorsByField

--- a/web/src/client/js/reducers/validation.js
+++ b/web/src/client/js/reducers/validation.js
@@ -20,6 +20,7 @@ export const validation = (state = initialState, action) => {
     case ActionTypes.CREATE_VALIDATION_ERRORS: {
       const resource = action.resource
       const errorsByField = groupBy(action.data.errorDetails, 'key')
+      console.log(errorsByField)
       return {
         ...state,
         [resource]: errorsByField


### PR DESCRIPTION
- adds field update validation for all field types
- max length on field input set to 255
- fixes bug where sync events were being sent even when field unsuccessfully updated

NOTE: isn't super helpful when a user is copy - pasting into the string field, it will just be truncated with no message