### PR TITLE
fix field update validation/fix meta bug

### DIFF
--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -85,8 +85,8 @@ const updateDocumentField = async function(fieldId, documentId, orgId, body, fil
   // NOTE: this will always result in error details being passed to the calling controller,
   // if we don't want these included in the payload, remove them there before sending
 
-  if (fieldBody.value) {
-    const { error } = fieldSchema.validate({ ...fieldBody, type: field.type })
+  if (body.value) {
+    const { error } = fieldSchema.validate({ ...body, type: field.type })
     if (error && error.name === 'ValidationError') {
       throw joiErrorToApiError(error, true)
     }

--- a/api/src/coordinators/field.test-u.js
+++ b/api/src/coordinators/field.test-u.js
@@ -29,7 +29,7 @@ describe('fieldCoordinator', () => {
     const documentId = 0
     const orgId = 0
     const fieldId = 999
-    const body = { type: 1, value: 'some-random-text', orgId: 0 }
+    const body = { type: 1, value: 'some-random-text' }
 
     beforeAll(() => {
       fieldCoordinator.addFieldToDocument = addFieldToDocument
@@ -194,7 +194,7 @@ describe('fieldCoordinator', () => {
     })
 
     describe('when it is an image field', () => {
-      const imageBody = { orgId: 0, value: 'not-a-real-update-value' }
+      const imageBody = { value: 'not-a-real-update-value' }
       const file = { buffer: new Buffer('not-a-real-buffer') }
       const mockReturnImageField = { ...mockReturnField, type: FIELD_TYPES.IMAGE, value: imageBody.value }
 

--- a/api/src/libs/fieldRenderedValue/index.js
+++ b/api/src/libs/fieldRenderedValue/index.js
@@ -47,8 +47,8 @@ export function getRenderedValueByType(field, value) {
         name,
         imageSource,
         alt: field.alt,
-        width: field.meta.width,
-        height: field.meta.height,
+        width: field.meta && field.meta.width,
+        height: field.meta && field.meta.height,
         alignment: field.alignment || IMAGE_ALIGNMENT_OPTIONS.CENTER,
         webpHalf: field.formats && field.formats.webp.half,
         webpFull: field.formats && field.formats.webp.full


### PR DESCRIPTION
- there was a bug with image fields where meta didn't exist, fixed here
- also field update validation should have been checking the original update body rather than the one we create in the coordinator, not sure how that got reverted, but also fixed here