### PR TITLE
always truncate image duplication filenames to 14 characters

### DIFF
--- a/api/src/coordinators/__mocks__/field.js
+++ b/api/src/coordinators/__mocks__/field.js
@@ -1,6 +1,6 @@
 export default {
   addFieldToDocument: jest.fn(),
-  addImageFieldFromUrlToDocument: jest.fn(),
+  addAssetFieldFromUrlToDocument: jest.fn(),
   updateDocumentField: jest.fn(),
   removeDocumentField: jest.fn(),
   duplicateField: jest.fn()

--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -51,13 +51,14 @@ const addImageFieldFromUrlToDocument = async function(documentId, body, url) {
 
   const fileStats = await callFuncWithArgs(stat, filePath)
 
-  const urlParts = url.split('/')
-  const name = urlParts[urlParts.length - 1]
+  const urlPath = path.parse(url)
+  // truncate the file name
+  const truncatedName = `${urlPath.name.slice(0, 14)}${urlPath.ext}`
 
   // This is mimic'ing multer's file object.
   // Not ideal to be passing the multer object around, but that's a larger rewrite to fix
   const file = {
-    originalname: name,
+    originalname: truncatedName,
     mimetype: lookup(url),
     path: filePath,
     size: fileStats.size

--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -42,7 +42,7 @@ const addFieldToDocument = async function(documentId, body, file) {
   return field
 }
 
-const addImageFieldFromUrlToDocument = async function(documentId, body, url) {
+const addAssetFieldFromUrlToDocument = async function(documentId, body, url) {
   const filePath = path.resolve(__dirname, `../../uploads/${documentId}-${Date.now()}`)
 
   const resp = await axios({ url, responseType: 'stream', method: 'get' })
@@ -53,7 +53,7 @@ const addImageFieldFromUrlToDocument = async function(documentId, body, url) {
 
   const urlPath = path.parse(url)
   // truncate the file name
-  const truncatedName = `${urlPath.name.slice(0, 14)}${urlPath.ext}`
+  const truncatedName = `${urlPath.name.slice(0, 13)}${urlPath.ext}`
 
   // This is mimic'ing multer's file object.
   // Not ideal to be passing the multer object around, but that's a larger rewrite to fix
@@ -178,8 +178,8 @@ const duplicateField = async function(id, originalParentDocId, newParentDocId, o
   }, {})
   body.orgId = orgId
 
-  if (body.type === FIELD_TYPES.IMAGE) {
-    return fieldCoordinator.addImageFieldFromUrlToDocument(newParentDocId, body, body.value)
+  if (body.type === FIELD_TYPES.IMAGE || body.type === FIELD_TYPES.FILE) {
+    return fieldCoordinator.addAssetFieldFromUrlToDocument(newParentDocId, body, body.value)
   } else if (body.type === FIELD_TYPES.DATE && typeof body.value === 'object') {
     body.value = body.value.toISOString()
   }
@@ -189,7 +189,7 @@ const duplicateField = async function(id, originalParentDocId, newParentDocId, o
 
 const fieldCoordinator = {
   addFieldToDocument,
-  addImageFieldFromUrlToDocument,
+  addAssetFieldFromUrlToDocument,
   updateDocumentField,
   removeDocumentField,
   duplicateField

--- a/api/src/coordinators/field.test-u.js
+++ b/api/src/coordinators/field.test-u.js
@@ -241,7 +241,7 @@ describe('fieldCoordinator', () => {
     })
   })
 
-  describe('#addImageFieldFromUrlToDocument', () => {
+  describe('#addAssetFieldFromUrlToDocument', () => {
     const url = 'https://bonkeybong.com/picture.jpg'
     const docId = 12
     const body = {
@@ -255,7 +255,7 @@ describe('fieldCoordinator', () => {
       })
       fieldCoordinator.addFieldToDocument.mockImplementationOnce()
       callFuncWithArgs.mockReturnValueOnce({ size: 143 })
-      await fieldCoordinator.addImageFieldFromUrlToDocument(docId, body, url)
+      await fieldCoordinator.addAssetFieldFromUrlToDocument(docId, body, url)
     })
 
     it('should call promisifyStreamPipe', () => {

--- a/api/src/coordinators/intro.js
+++ b/api/src/coordinators/intro.js
@@ -44,7 +44,7 @@ const copyIntroProjectToOrg = async (orgId) => {
       body.orgId = orgId
 
       if (body.type === FIELD_TYPES.IMAGE) {
-        return fieldCoordinator.addImageFieldFromUrlToDocument(newDoc.id, body, field.value)
+        return fieldCoordinator.addAssetFieldFromUrlToDocument(newDoc.id, body, field.value)
       }
       return BusinessField.createForDocument(newDoc.id, body)
     }, Promise.resolve())

--- a/api/src/coordinators/intro.test-u.js
+++ b/api/src/coordinators/intro.test-u.js
@@ -73,8 +73,8 @@ describe('introCoordinator', () => {
       expect(BusinessDocument.createForProject.mock.calls.length).toBe(2)
     })
 
-    it('should call fieldCoordinator.addImageFieldFromUrlToDocument', () => {
-      expect(fieldCoordinator.addImageFieldFromUrlToDocument.mock.calls.length).toBe(2)
+    it('should call fieldCoordinator.addAssetFieldFromUrlToDocument', () => {
+      expect(fieldCoordinator.addAssetFieldFromUrlToDocument.mock.calls.length).toBe(2)
     })
 
     it('should call BusinessField.createForDocument', () => {


### PR DESCRIPTION
fixes copying a copy of a copy of a copy of a copy bug