### PR TITLE
ensure body.value before running additional processes on field value

### DIFF
--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -183,10 +183,10 @@ const duplicateField = async function(id, originalParentDocId, newParentDocId, o
     return body
   }, {})
   body.orgId = orgId
-
-  if (body.type === FIELD_TYPES.IMAGE || body.type === FIELD_TYPES.FILE) {
+  console.log(body)
+  if (body.type === FIELD_TYPES.IMAGE || body.type === FIELD_TYPES.FILE && body.value) {
     return fieldCoordinator.addAssetFieldFromUrlToDocument(newParentDocId, body, body.value)
-  } else if (body.type === FIELD_TYPES.DATE && typeof body.value === 'object') {
+  } else if (body.type === FIELD_TYPES.DATE && typeof body.value === 'object' && body.value) {
     body.value = body.value.toISOString()
   }
 

--- a/api/src/coordinators/field.js
+++ b/api/src/coordinators/field.js
@@ -183,7 +183,6 @@ const duplicateField = async function(id, originalParentDocId, newParentDocId, o
     return body
   }, {})
   body.orgId = orgId
-  console.log(body)
   if (body.type === FIELD_TYPES.IMAGE || body.type === FIELD_TYPES.FILE && body.value) {
     return fieldCoordinator.addAssetFieldFromUrlToDocument(newParentDocId, body, body.value)
   } else if (body.type === FIELD_TYPES.DATE && typeof body.value === 'object' && body.value) {


### PR DESCRIPTION
we were getting 500s when trying to duplicate documents with an empty image field, this add an additional check for a current body.value url before doing the duplication