### PR TITLE
Changes responsive image to picture tag with fallback for webp

### DIFF
--- a/api/src/controllers/payloadSchemas/adminImageFieldFormats.js
+++ b/api/src/controllers/payloadSchemas/adminImageFieldFormats.js
@@ -3,11 +3,13 @@ import Joi from '@hapi/joi'
 export const rawSchema = {
   webp: Joi.object({
     half: Joi.string().uri(),
-    full: Joi.string().uri()
+    full: Joi.string().uri(),
+    mimeType: Joi.string()
   }),
   original: Joi.object({
     half: Joi.string().uri(),
-    full: Joi.string().uri()
+    full: Joi.string().uri(),
+    mimeType: Joi.string()
   })
 }
 

--- a/api/src/libs/fieldRenderedValue/fieldRenderedValue.test-i.js
+++ b/api/src/libs/fieldRenderedValue/fieldRenderedValue.test-i.js
@@ -74,7 +74,7 @@ describe('fieldRenderedValue', () => {
           result = await getRenderedValueByType({
             ...field,
             formats: {
-              webp: { webPhalf, webPfull },
+              webp: { half: webPhalf, full: webPfull },
               original: { half: originalHalf, full: originalFull }
             }
           }, value)

--- a/api/src/libs/fieldRenderedValue/fieldRenderedValue.test-i.js
+++ b/api/src/libs/fieldRenderedValue/fieldRenderedValue.test-i.js
@@ -68,7 +68,7 @@ describe('fieldRenderedValue', () => {
         const half = 'webphalfsource'
         const full = 'webpfullsource'
 
-        beforeAll(async () => {   
+        beforeAll(async () => {
           result = await getRenderedValueByType({ ...field, formats: { webp: { half, full } } }, value)
         })
 

--- a/api/src/libs/fieldRenderedValue/fieldRenderedValue.test-i.js
+++ b/api/src/libs/fieldRenderedValue/fieldRenderedValue.test-i.js
@@ -65,11 +65,19 @@ describe('fieldRenderedValue', () => {
       })
 
       describe('when there is a webp value', () => {
-        const half = 'webphalfsource'
-        const full = 'webpfullsource'
+        const webPhalf = 'webphalfsource'
+        const webPfull = 'webpfullsource'
+        const originalHalf = 'originalHalf'
+        const originalFull = 'originalFull'
 
         beforeAll(async () => {
-          result = await getRenderedValueByType({ ...field, formats: { webp: { half, full } } }, value)
+          result = await getRenderedValueByType({
+            ...field,
+            formats: {
+              webp: { webPhalf, webPfull },
+              original: { half: originalHalf, full: originalFull }
+            }
+          }, value)
         })
 
         it('should return a rendered string containing the name and value', () => {
@@ -77,8 +85,8 @@ describe('fieldRenderedValue', () => {
           expect(result).toContain(field.meta.width)
           expect(result).toContain(field.meta.height)
           expect(result).toContain(field.alignment)
-          expect(result).toContain(half)
-          expect(result).toContain(full)
+          expect(result).toContain(webPhalf)
+          expect(result).toContain(webPfull)
         })
       })
     })

--- a/api/src/libs/fieldRenderedValue/image.html
+++ b/api/src/libs/fieldRenderedValue/image.html
@@ -1,7 +1,11 @@
 <div data-source="portway" data-type="<%= type %>" data-name="<%= name %>" data-align="<%= alignment %>">
+  <% if (originalMimeType !== "image/svg+xml") { %>
   <picture>
     <source type="image/webp" srcset="<%= webpHalf %>, <%= webpFull %> 2x">
     <source type="<%= originalMimeType %>" srcset="<%= originalHalf %>, <%= originalFull %> 2x">
     <img src="<%= value %>" alt="<%= alt %>" width="<%= width %>" height="<%= height %>" align="<%= alignment %>" />
   </picture>
+  <% } else { %>
+    <img src="<%= value %>" alt="<%= alt %>" width="<%= width %>" height="<%= height %>" align="<%= alignment %>" />
+  <% } %>
 </div>

--- a/api/src/libs/fieldRenderedValue/image.html
+++ b/api/src/libs/fieldRenderedValue/image.html
@@ -1,4 +1,7 @@
 <div data-source="portway" data-type="<%= type %>" data-name="<%= name %>" data-align="<%= alignment %>">
-  <img src="<%= imageSource %>" srcSet="<%= webpHalf %>, <%= webpFull %> 2x" alt="<%= alt %>"
-    width="<%= width %>" height="<%= height %>" align="<%= alignment %>" />
+  <picture>
+    <source type="image/webp" srcset="<%= webpHalf %>, <%= webpFull %> 2x">
+    <source type="<JJ_HERE>" srcset="<%= originalHalf %>, <%= originalFull %> 2x">
+    <img src="<%= imageSource %>" alt="<%= alt %>" width="<%= width %>" height="<%= height %>" align="<%= alignment %>" />
+  </picture>
 </div>

--- a/api/src/libs/fieldRenderedValue/image.html
+++ b/api/src/libs/fieldRenderedValue/image.html
@@ -2,6 +2,6 @@
   <picture>
     <source type="image/webp" srcset="<%= webpHalf %>, <%= webpFull %> 2x">
     <source type="<JJ_HERE>" srcset="<%= originalHalf %>, <%= originalFull %> 2x">
-    <img src="<%= imageSource %>" alt="<%= alt %>" width="<%= width %>" height="<%= height %>" align="<%= alignment %>" />
+    <img src="<%= value %>" alt="<%= alt %>" width="<%= width %>" height="<%= height %>" align="<%= alignment %>" />
   </picture>
 </div>

--- a/api/src/libs/fieldRenderedValue/image.html
+++ b/api/src/libs/fieldRenderedValue/image.html
@@ -1,7 +1,7 @@
 <div data-source="portway" data-type="<%= type %>" data-name="<%= name %>" data-align="<%= alignment %>">
   <picture>
     <source type="image/webp" srcset="<%= webpHalf %>, <%= webpFull %> 2x">
-    <source type="<JJ_HERE>" srcset="<%= originalHalf %>, <%= originalFull %> 2x">
+    <source type="<%= originalMimeType %>" srcset="<%= originalHalf %>, <%= originalFull %> 2x">
     <img src="<%= value %>" alt="<%= alt %>" width="<%= width %>" height="<%= height %>" align="<%= alignment %>" />
   </picture>
 </div>

--- a/api/src/libs/fieldRenderedValue/index.js
+++ b/api/src/libs/fieldRenderedValue/index.js
@@ -51,7 +51,9 @@ export function getRenderedValueByType(field, value) {
         height: field.meta && field.meta.height,
         alignment: field.alignment || IMAGE_ALIGNMENT_OPTIONS.CENTER,
         webpHalf: field.formats && field.formats.webp.half,
-        webpFull: field.formats && field.formats.webp.full
+        webpFull: field.formats && field.formats.webp.full,
+        originalHalf: field.formats && field.formats.original.half,
+        originalFull: field.formats && field.formats.original.full,
       })
     case FIELD_TYPES.NUMBER:
       return EJS_TEMPLATE_FUNCTIONS[FIELD_TYPES.NUMBER]({ type: 'number', name, value })

--- a/api/src/libs/fieldRenderedValue/index.js
+++ b/api/src/libs/fieldRenderedValue/index.js
@@ -53,6 +53,7 @@ export function getRenderedValueByType(field, value) {
         webpFull: field.formats && field.formats.webp.full,
         originalHalf: field.formats && field.formats.original.half,
         originalFull: field.formats && field.formats.original.full,
+        originalMimeType: field.formats && field.formats.original.mimeType
       })
     case FIELD_TYPES.NUMBER:
       return EJS_TEMPLATE_FUNCTIONS[FIELD_TYPES.NUMBER]({ type: 'number', name, value })

--- a/api/src/libs/fieldRenderedValue/index.js
+++ b/api/src/libs/fieldRenderedValue/index.js
@@ -41,11 +41,10 @@ export function getRenderedValueByType(field, value) {
       const html = renderMarkdownSync(value)
       return EJS_TEMPLATE_FUNCTIONS[FIELD_TYPES.TEXT]({ html, type: 'text', name })
     case FIELD_TYPES.IMAGE:
-      const imageSource = field.formats ? field.formats.webp.half : value
       return EJS_TEMPLATE_FUNCTIONS[FIELD_TYPES.IMAGE]({
         type: 'image',
         name,
-        imageSource,
+        value,
         alt: field.alt,
         width: field.meta && field.meta.width,
         height: field.meta && field.meta.height,

--- a/web/src/client/js/components/DocumentPanel/DocumentFieldSettings/DocumentFieldSettingsComponent.js
+++ b/web/src/client/js/components/DocumentPanel/DocumentFieldSettings/DocumentFieldSettingsComponent.js
@@ -64,10 +64,10 @@ const DocumentFieldSettingsComponent = ({ field, isUpdating, updateHandler }) =>
       {field.type === FIELD_TYPES.IMAGE && field.value &&
       <a className="document-panel__image-link" href={field.value} target="_blank" rel="noopener noreferrer">
         <picture>
-          {field.formats && field.formats.webp &&
+          {field.formats && field.formats.webp && field.formats.original.mimeType !== 'image/svg+xml' &&
           <source type="image/webp" srcSet={`${field.formats.webp.half}, ${field.formats.webp.full} 2x`} />
           }
-          {field.formats && field.formats.original &&
+          {field.formats && field.formats.original && field.formats.original.mimeType !== 'image/svg+xml' &&
           <source type={field.formats.original.mimeType} srcSet={`${field.formats.original.half}, ${field.formats.original.full} 2x`} />
           }
           <img src={field.value} width={field.meta && field.meta.width} height={field.meta && field.meta.height} alt={field.alt && field.alt} />

--- a/web/src/client/js/components/DocumentPanel/DocumentFieldSettings/DocumentFieldSettingsComponent.js
+++ b/web/src/client/js/components/DocumentPanel/DocumentFieldSettings/DocumentFieldSettingsComponent.js
@@ -68,7 +68,7 @@ const DocumentFieldSettingsComponent = ({ field, isUpdating, updateHandler }) =>
           <source type="image/webp" srcSet={`${field.formats.webp.half}, ${field.formats.webp.full} 2x`} />
           }
           {field.formats && field.formats.original &&
-          <source type="<JJ_HERE>" srcSet={`${field.formats.original.half}, ${field.formats.original.full} 2x`} />
+          <source type={field.formats.original.mimeType} srcSet={`${field.formats.original.half}, ${field.formats.original.full} 2x`} />
           }
           <img src={field.value} width={field.meta && field.meta.width} height={field.meta && field.meta.height} alt={field.alt && field.alt} />
         </picture>

--- a/web/src/client/js/components/DocumentPanel/DocumentFieldSettings/DocumentFieldSettingsComponent.js
+++ b/web/src/client/js/components/DocumentPanel/DocumentFieldSettings/DocumentFieldSettingsComponent.js
@@ -63,7 +63,15 @@ const DocumentFieldSettingsComponent = ({ field, isUpdating, updateHandler }) =>
 
       {field.type === FIELD_TYPES.IMAGE && field.value &&
       <a className="document-panel__image-link" href={field.value} target="_blank" rel="noopener noreferrer">
-        <img src={field.value} width={field.meta && field.meta.width} height={field.meta && field.meta.height} alt={field.alt && field.alt} />
+        <picture>
+          {field.formats && field.formats.webp &&
+          <source type="image/webp" srcSet={`${field.formats.webp.half}, ${field.formats.webp.full} 2x`} />
+          }
+          {field.formats && field.formats.original &&
+          <source type="<JJ_HERE>" srcSet={`${field.formats.original.half}, ${field.formats.original.full} 2x`} />
+          }
+          <img src={field.value} width={field.meta && field.meta.width} height={field.meta && field.meta.height} alt={field.alt && field.alt} />
+        </picture>
       </a>
       }
 

--- a/web/src/client/js/components/FieldImage/FieldImageComponent.js
+++ b/web/src/client/js/components/FieldImage/FieldImageComponent.js
@@ -132,10 +132,10 @@ const FieldImageComponent = ({
       <div className={containerClassnames}>
         {imageSrc &&
         <picture>
-          {webpSource.current &&
+          {webpSource.current && field.formats && field.formats.original.mimeType !== 'image/svg+xml' &&
           <source type="image/webp" srcSet={`${webpSource.current.half}, ${webpSource.current.full} 2x`} />
           }
-          {originalSource.current &&
+          {originalSource.current && field.formats && field.formats.original.mimeType !== 'image/svg+xml' &&
           <source type={field.formats.original.mimeType} srcSet={`${originalSource.current.half}, ${originalSource.current.full} 2x`} />
           }
           <img

--- a/web/src/client/js/components/FieldImage/FieldImageComponent.js
+++ b/web/src/client/js/components/FieldImage/FieldImageComponent.js
@@ -136,7 +136,7 @@ const FieldImageComponent = ({
           <source type="image/webp" srcSet={`${webpSource.current.half}, ${webpSource.current.full} 2x`} />
           }
           {originalSource.current &&
-          <source type="<JJ_HERE>" srcSet={`${originalSource.current.half}, ${originalSource.current.full} 2x`} />
+          <source type={field.formats.original.mimeType} srcSet={`${originalSource.current.half}, ${originalSource.current.full} 2x`} />
           }
           <img
             alt={field && field.name}

--- a/web/src/client/js/components/FieldImage/FieldImageComponent.js
+++ b/web/src/client/js/components/FieldImage/FieldImageComponent.js
@@ -43,6 +43,7 @@ const FieldImageComponent = ({
   const previousField = usePrevious(field)
 
   // // Use the formats if we have them
+  const originalSource = useRef(field.formats && field.formats.original)
   const webpSource = useRef(field.formats && field.formats.webp)
 
   // Name
@@ -54,6 +55,7 @@ const FieldImageComponent = ({
   // if the image is updated in the settings panel, webp will be wiped out until the image can process in the background
   // in these cases, formats will be undefined and we want the component to reflect that
   useEffect(() => {
+    originalSource.current = field.formats && field.formats.original
     webpSource.current = field.formats && field.formats.webp
   }, [field.formats])
 
@@ -71,6 +73,7 @@ const FieldImageComponent = ({
         if (isMounted.current) {
           // Reset all stored image values, and show the preview
           imageNodeRef.current.setAttribute('srcset', '')
+          originalSource.current = null
           webpSource.current = null
           setImageSrc(e.target.result)
         }
@@ -128,16 +131,23 @@ const FieldImageComponent = ({
     <figure className={imageFieldClassNames}>
       <div className={containerClassnames}>
         {imageSrc &&
-        <img
-          alt={field && field.name}
-          className={imageClassnames}
-          height={field.meta && field.meta.height}
-          lazy="true"
-          ref={imageNodeRef}
-          src={webpSource.current ? webpSource.current.half : imageSrc}
-          srcSet={webpSource.current ? `${webpSource.current.half}, ${webpSource.current.full} 2x` : ``}
-          width={field.meta && field.meta.width}
-        />
+        <picture>
+          {webpSource.current &&
+          <source type="image/webp" srcSet={`${webpSource.current.half}, ${webpSource.current.full} 2x`} />
+          }
+          {originalSource.current &&
+          <source type="<JJ_HERE>" srcSet={`${originalSource.current.half}, ${originalSource.current.full} 2x`} />
+          }
+          <img
+            alt={field && field.name}
+            className={imageClassnames}
+            height={field.meta && field.meta.height}
+            lazy="true"
+            ref={imageNodeRef}
+            src={imageSrc}
+            width={field.meta && field.meta.width}
+          />
+        </picture>
         }
         <FileUploaderComponent
           accept="image/*"

--- a/workers/src/coordinators/imageProcessing.js
+++ b/workers/src/coordinators/imageProcessing.js
@@ -73,11 +73,13 @@ const createImageAlternatives = async function(url, documentId, fieldId, orgId) 
   const formatData = {
     original: {
       full: url,
-      half: originalHalfResult.Location
+      half: originalHalfResult.Location,
+      mimeType: originalMimetype
     },
     webp: {
       full: webPFullResult.Location,
-      half: webPHalfResult.Location
+      half: webPHalfResult.Location,
+      mimeType: 'image/webp'
     }
   }
 

--- a/workers/src/coordinators/imageProcessing.test-u.js
+++ b/workers/src/coordinators/imageProcessing.test-u.js
@@ -15,7 +15,7 @@ describe('imageProcessingCoordinator', () => {
     const documentId = 111111
     const orgId = 222222
     const fieldId = 333333
-    const fileUrl = 'not-a-real-s3-file-url'
+    const fileUrl = 'not-a-real-s3-file-url.jpg'
     const location = 'not-a-real-location'
     const resp = { data: 'not-real-data' }
     let result
@@ -65,11 +65,13 @@ describe('imageProcessingCoordinator', () => {
       expect(portwayAPI.updateFieldFormats.mock.calls[0][3]).toEqual({
         original: {
           full: fileUrl,
-          half: location
+          half: location,
+          mimeType: 'image/jpeg'
         },
         webp: {
           full: location,
-          half: location
+          half: location,
+          mimeType: 'image/webp'
         }
       })
     })


### PR DESCRIPTION
* Uses `<picture>` tag everywhere for responsive images, falling back to original format if webp is not supported

@jjidt needs:

1. Add mime-type to each image format:
    ```javascript
    formats: {
      webp: {
        original: ...,
        half: ...,
        mimeType: ....
      }
    }
    ```
2. Add mime-type to the `type` attribute in the three spots marked `<JJ_HERE>`
3. Add a conditional in each case to display SVGs as normal img tags, not in a picture tag with any formats